### PR TITLE
chore: release v0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-bundle"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64",
  "hex",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-conformance"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64",
  "hex",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-crypto"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -1630,7 +1630,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-fulcio"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64",
  "hex",
@@ -1646,7 +1646,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-merkle"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64",
  "hex",
@@ -1660,7 +1660,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-oidc"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64",
  "rand",
@@ -1676,7 +1676,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-rekor"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64",
  "hex",
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-sign"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64",
  "sigstore-bundle",
@@ -1710,7 +1710,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-trust-root"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64",
  "chrono",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-tsa"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-types"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64",
  "chrono",
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-verify"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/sigstore/sigultimate"
@@ -84,14 +84,14 @@ futures = "0.3"
 directories = "6.0"
 
 # Internal crates (path + version for publishing)
-sigstore-types = { path = "crates/sigstore-types", version = "0.1.0" }
-sigstore-crypto = { path = "crates/sigstore-crypto", version = "0.1.0" }
-sigstore-merkle = { path = "crates/sigstore-merkle", version = "0.1.0" }
-sigstore-tsa = { path = "crates/sigstore-tsa", version = "0.1.0" }
-sigstore-trust-root = { path = "crates/sigstore-trust-root", version = "0.1.0" }
-sigstore-bundle = { path = "crates/sigstore-bundle", version = "0.1.0" }
-sigstore-rekor = { path = "crates/sigstore-rekor", version = "0.1.0" }
-sigstore-fulcio = { path = "crates/sigstore-fulcio", version = "0.1.0" }
-sigstore-oidc = { path = "crates/sigstore-oidc", version = "0.1.0" }
-sigstore-verify = { path = "crates/sigstore-verify", version = "0.1.0" }
-sigstore-sign = { path = "crates/sigstore-sign", version = "0.1.0" }
+sigstore-types = { path = "crates/sigstore-types", version = "0.1.1" }
+sigstore-crypto = { path = "crates/sigstore-crypto", version = "0.1.1" }
+sigstore-merkle = { path = "crates/sigstore-merkle", version = "0.1.1" }
+sigstore-tsa = { path = "crates/sigstore-tsa", version = "0.1.1" }
+sigstore-trust-root = { path = "crates/sigstore-trust-root", version = "0.1.1" }
+sigstore-bundle = { path = "crates/sigstore-bundle", version = "0.1.1" }
+sigstore-rekor = { path = "crates/sigstore-rekor", version = "0.1.1" }
+sigstore-fulcio = { path = "crates/sigstore-fulcio", version = "0.1.1" }
+sigstore-oidc = { path = "crates/sigstore-oidc", version = "0.1.1" }
+sigstore-verify = { path = "crates/sigstore-verify", version = "0.1.1" }
+sigstore-sign = { path = "crates/sigstore-sign", version = "0.1.1" }

--- a/crates/sigstore-bundle/CHANGELOG.md
+++ b/crates/sigstore-bundle/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/wolfv/sigstore-rust/compare/sigstore-bundle-v0.1.0...sigstore-bundle-v0.1.1) - 2025-11-27
+
+### Fixed
+
+- fix publishing
+- fix clippy
+- fix up
+- fix other conformance issue
+
+### Other
+
+- fmt
+- more type safety
+- more simplifications
+- slim down codebase
+- some clean up
+- improve dsse verification
+- add happy-path bundle
+- remove raw json stuff as it should not be needed
+- hash raw dsse
+- more type safety
+- type safety improvements
+- make the conformance suite pass
+- initial commit

--- a/crates/sigstore-crypto/CHANGELOG.md
+++ b/crates/sigstore-crypto/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/wolfv/sigstore-rust/compare/sigstore-crypto-v0.1.0...sigstore-crypto-v0.1.1) - 2025-11-27
+
+### Fixed
+
+- fix verification

--- a/crates/sigstore-fulcio/CHANGELOG.md
+++ b/crates/sigstore-fulcio/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/wolfv/sigstore-rust/compare/sigstore-fulcio-v0.1.0...sigstore-fulcio-v0.1.1) - 2025-11-27
+
+### Fixed
+
+- fix publishing
+
+### Other
+
+- fmt
+- hash raw dsse
+- initial commit

--- a/crates/sigstore-merkle/CHANGELOG.md
+++ b/crates/sigstore-merkle/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/sigstore-oidc/CHANGELOG.md
+++ b/crates/sigstore-oidc/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/wolfv/sigstore-rust/compare/sigstore-oidc-v0.1.0...sigstore-oidc-v0.1.1) - 2025-11-27
+
+### Fixed
+
+- fix publishing
+
+### Other
+
+- some clean up
+- slim down dependency tree
+- initial commit

--- a/crates/sigstore-rekor/CHANGELOG.md
+++ b/crates/sigstore-rekor/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/sigstore-sign/CHANGELOG.md
+++ b/crates/sigstore-sign/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/wolfv/sigstore-rust/compare/sigstore-sign-v0.1.0...sigstore-sign-v0.1.1) - 2025-11-27
+
+### Fixed
+
+- fix publishing
+
+### Other
+
+- add new crates

--- a/crates/sigstore-trust-root/CHANGELOG.md
+++ b/crates/sigstore-trust-root/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/wolfv/sigstore-rust/compare/sigstore-trust-root-v0.1.0...sigstore-trust-root-v0.1.1) - 2025-11-27
+
+### Other
+
+- fmt

--- a/crates/sigstore-tsa/CHANGELOG.md
+++ b/crates/sigstore-tsa/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/wolfv/sigstore-rust/compare/sigstore-tsa-v0.1.0...sigstore-tsa-v0.1.1) - 2025-11-27
+
+### Other
+
+- update Cargo.toml dependencies

--- a/crates/sigstore-types/CHANGELOG.md
+++ b/crates/sigstore-types/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/sigstore-verify/CHANGELOG.md
+++ b/crates/sigstore-verify/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/wolfv/sigstore-rust/compare/sigstore-verify-v0.1.0...sigstore-verify-v0.1.1) - 2025-11-27
+
+### Fixed
+
+- fix verification
+- fix publishing
+
+### Other
+
+- add conformance test
+- add all test data
+- add tests for verify
+- add new crates


### PR DESCRIPTION



## 🤖 New release

* `sigstore-types`: 0.1.0 -> 0.1.1
* `sigstore-crypto`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `sigstore-merkle`: 0.1.0 -> 0.1.1
* `sigstore-tsa`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `sigstore-trust-root`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `sigstore-rekor`: 0.1.0 -> 0.1.1
* `sigstore-bundle`: 0.1.0 -> 0.1.1
* `sigstore-fulcio`: 0.1.0 -> 0.1.1
* `sigstore-oidc`: 0.1.0 -> 0.1.1
* `sigstore-verify`: 0.1.0 -> 0.1.1
* `sigstore-sign`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>


## `sigstore-crypto`

<blockquote>

## [0.1.1](https://github.com/wolfv/sigstore-rust/compare/sigstore-crypto-v0.1.0...sigstore-crypto-v0.1.1) - 2025-11-27

### Fixed

- fix verification
</blockquote>


## `sigstore-tsa`

<blockquote>

## [0.1.1](https://github.com/wolfv/sigstore-rust/compare/sigstore-tsa-v0.1.0...sigstore-tsa-v0.1.1) - 2025-11-27

### Other

- update Cargo.toml dependencies
</blockquote>

## `sigstore-trust-root`

<blockquote>

## [0.1.1](https://github.com/wolfv/sigstore-rust/compare/sigstore-trust-root-v0.1.0...sigstore-trust-root-v0.1.1) - 2025-11-27

### Other

- fmt
</blockquote>


## `sigstore-bundle`

<blockquote>

## [0.1.1](https://github.com/wolfv/sigstore-rust/compare/sigstore-bundle-v0.1.0...sigstore-bundle-v0.1.1) - 2025-11-27

### Fixed

- fix publishing
- fix clippy
- fix up
- fix other conformance issue

### Other

- fmt
- more type safety
- more simplifications
- slim down codebase
- some clean up
- improve dsse verification
- add happy-path bundle
- remove raw json stuff as it should not be needed
- hash raw dsse
- more type safety
- type safety improvements
- make the conformance suite pass
- initial commit
</blockquote>

## `sigstore-fulcio`

<blockquote>

## [0.1.1](https://github.com/wolfv/sigstore-rust/compare/sigstore-fulcio-v0.1.0...sigstore-fulcio-v0.1.1) - 2025-11-27

### Fixed

- fix publishing

### Other

- fmt
- hash raw dsse
- initial commit
</blockquote>

## `sigstore-oidc`

<blockquote>

## [0.1.1](https://github.com/wolfv/sigstore-rust/compare/sigstore-oidc-v0.1.0...sigstore-oidc-v0.1.1) - 2025-11-27

### Fixed

- fix publishing

### Other

- some clean up
- slim down dependency tree
- initial commit
</blockquote>

## `sigstore-verify`

<blockquote>

## [0.1.1](https://github.com/wolfv/sigstore-rust/compare/sigstore-verify-v0.1.0...sigstore-verify-v0.1.1) - 2025-11-27

### Fixed

- fix verification
- fix publishing

### Other

- add conformance test
- add all test data
- add tests for verify
- add new crates
</blockquote>

## `sigstore-sign`

<blockquote>

## [0.1.1](https://github.com/wolfv/sigstore-rust/compare/sigstore-sign-v0.1.0...sigstore-sign-v0.1.1) - 2025-11-27

### Fixed

- fix publishing

### Other

- add new crates
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).