### PR TITLE
chore: release v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-bundle"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64",
  "hex",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-conformance"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64",
  "hex",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-crypto"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -1630,7 +1630,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-fulcio"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64",
  "hex",
@@ -1646,7 +1646,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-merkle"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64",
  "hex",
@@ -1660,7 +1660,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-oidc"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64",
  "rand",
@@ -1676,7 +1676,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-rekor"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64",
  "hex",
@@ -1693,7 +1693,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-sign"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64",
  "sigstore-bundle",
@@ -1710,7 +1710,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-trust-root"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64",
  "chrono",
@@ -1732,7 +1732,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-tsa"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -1758,7 +1758,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-types"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64",
  "chrono",
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-verify"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 license = "BSD-3-Clause"
 repository = "https://github.com/sigstore/sigultimate"
@@ -84,14 +84,14 @@ futures = "0.3"
 directories = "6.0"
 
 # Internal crates (path + version for publishing)
-sigstore-types = { path = "crates/sigstore-types", version = "0.1.1" }
-sigstore-crypto = { path = "crates/sigstore-crypto", version = "0.1.1" }
-sigstore-merkle = { path = "crates/sigstore-merkle", version = "0.1.1" }
-sigstore-tsa = { path = "crates/sigstore-tsa", version = "0.1.1" }
-sigstore-trust-root = { path = "crates/sigstore-trust-root", version = "0.1.1" }
-sigstore-bundle = { path = "crates/sigstore-bundle", version = "0.1.1" }
-sigstore-rekor = { path = "crates/sigstore-rekor", version = "0.1.1" }
-sigstore-fulcio = { path = "crates/sigstore-fulcio", version = "0.1.1" }
-sigstore-oidc = { path = "crates/sigstore-oidc", version = "0.1.1" }
-sigstore-verify = { path = "crates/sigstore-verify", version = "0.1.1" }
-sigstore-sign = { path = "crates/sigstore-sign", version = "0.1.1" }
+sigstore-types = { path = "crates/sigstore-types", version = "0.2.0" }
+sigstore-crypto = { path = "crates/sigstore-crypto", version = "0.2.0" }
+sigstore-merkle = { path = "crates/sigstore-merkle", version = "0.2.0" }
+sigstore-tsa = { path = "crates/sigstore-tsa", version = "0.2.0" }
+sigstore-trust-root = { path = "crates/sigstore-trust-root", version = "0.2.0" }
+sigstore-bundle = { path = "crates/sigstore-bundle", version = "0.2.0" }
+sigstore-rekor = { path = "crates/sigstore-rekor", version = "0.2.0" }
+sigstore-fulcio = { path = "crates/sigstore-fulcio", version = "0.2.0" }
+sigstore-oidc = { path = "crates/sigstore-oidc", version = "0.2.0" }
+sigstore-verify = { path = "crates/sigstore-verify", version = "0.2.0" }
+sigstore-sign = { path = "crates/sigstore-sign", version = "0.2.0" }

--- a/crates/sigstore-bundle/CHANGELOG.md
+++ b/crates/sigstore-bundle/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-bundle-v0.1.1...sigstore-bundle-v0.2.0) - 2025-11-27
+
+### Other
+
+- remove duplicated types, add license and readme files
+
 ## [0.1.1](https://github.com/wolfv/sigstore-rust/compare/sigstore-bundle-v0.1.0...sigstore-bundle-v0.1.1) - 2025-11-27
 
 ### Fixed

--- a/crates/sigstore-crypto/CHANGELOG.md
+++ b/crates/sigstore-crypto/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-crypto-v0.1.1...sigstore-crypto-v0.2.0) - 2025-11-27
+
+### Other
+
+- format
+- remove duplicated types, add license and readme files
+
 ## [0.1.1](https://github.com/wolfv/sigstore-rust/compare/sigstore-crypto-v0.1.0...sigstore-crypto-v0.1.1) - 2025-11-27
 
 ### Fixed

--- a/crates/sigstore-fulcio/CHANGELOG.md
+++ b/crates/sigstore-fulcio/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-fulcio-v0.1.1...sigstore-fulcio-v0.2.0) - 2025-11-27
+
+### Other
+
+- remove duplicated types, add license and readme files
+
 ## [0.1.1](https://github.com/wolfv/sigstore-rust/compare/sigstore-fulcio-v0.1.0...sigstore-fulcio-v0.1.1) - 2025-11-27
 
 ### Fixed

--- a/crates/sigstore-merkle/CHANGELOG.md
+++ b/crates/sigstore-merkle/CHANGELOG.md
@@ -6,3 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-merkle-v0.1.1...sigstore-merkle-v0.2.0) - 2025-11-27
+
+### Other
+
+- remove unused function
+- remove duplicated types, add license and readme files

--- a/crates/sigstore-oidc/CHANGELOG.md
+++ b/crates/sigstore-oidc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-oidc-v0.1.1...sigstore-oidc-v0.2.0) - 2025-11-27
+
+### Other
+
+- remove duplicated types, add license and readme files
+
 ## [0.1.1](https://github.com/wolfv/sigstore-rust/compare/sigstore-oidc-v0.1.0...sigstore-oidc-v0.1.1) - 2025-11-27
 
 ### Fixed

--- a/crates/sigstore-rekor/CHANGELOG.md
+++ b/crates/sigstore-rekor/CHANGELOG.md
@@ -6,3 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-rekor-v0.1.1...sigstore-rekor-v0.2.0) - 2025-11-27
+
+### Other
+
+- remove duplicated types, add license and readme files

--- a/crates/sigstore-sign/CHANGELOG.md
+++ b/crates/sigstore-sign/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-sign-v0.1.1...sigstore-sign-v0.2.0) - 2025-11-27
+
+### Other
+
+- remove duplicated types, add license and readme files
+
 ## [0.1.1](https://github.com/wolfv/sigstore-rust/compare/sigstore-sign-v0.1.0...sigstore-sign-v0.1.1) - 2025-11-27
 
 ### Fixed

--- a/crates/sigstore-trust-root/CHANGELOG.md
+++ b/crates/sigstore-trust-root/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-trust-root-v0.1.1...sigstore-trust-root-v0.2.0) - 2025-11-27
+
+### Other
+
+- remove duplicated types, add license and readme files
+
 ## [0.1.1](https://github.com/wolfv/sigstore-rust/compare/sigstore-trust-root-v0.1.0...sigstore-trust-root-v0.1.1) - 2025-11-27
 
 ### Other

--- a/crates/sigstore-tsa/CHANGELOG.md
+++ b/crates/sigstore-tsa/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-tsa-v0.1.1...sigstore-tsa-v0.2.0) - 2025-11-27
+
+### Other
+
+- require trust root in constructor, remove more unused code, update readme
+- remove duplicated types, add license and readme files
+
 ## [0.1.1](https://github.com/wolfv/sigstore-rust/compare/sigstore-tsa-v0.1.0...sigstore-tsa-v0.1.1) - 2025-11-27
 
 ### Other

--- a/crates/sigstore-types/CHANGELOG.md
+++ b/crates/sigstore-types/CHANGELOG.md
@@ -6,3 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-types-v0.1.1...sigstore-types-v0.2.0) - 2025-11-27
+
+### Other
+
+- more dead code removal
+- format
+- remove duplicated types, add license and readme files

--- a/crates/sigstore-verify/CHANGELOG.md
+++ b/crates/sigstore-verify/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-verify-v0.1.1...sigstore-verify-v0.2.0) - 2025-11-27
+
+### Other
+
+- require trust root in constructor, remove more unused code, update readme
+- remove duplicated types, add license and readme files
+
 ## [0.1.1](https://github.com/wolfv/sigstore-rust/compare/sigstore-verify-v0.1.0...sigstore-verify-v0.1.1) - 2025-11-27
 
 ### Fixed


### PR DESCRIPTION



## 🤖 New release

* `sigstore-types`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)
* `sigstore-crypto`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)
* `sigstore-merkle`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)
* `sigstore-tsa`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)
* `sigstore-trust-root`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)
* `sigstore-rekor`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)
* `sigstore-bundle`: 0.1.1 -> 0.2.0 (✓ API compatible changes)
* `sigstore-fulcio`: 0.1.1 -> 0.2.0 (✓ API compatible changes)
* `sigstore-oidc`: 0.1.1 -> 0.2.0 (✓ API compatible changes)
* `sigstore-verify`: 0.1.1 -> 0.2.0 (⚠ API breaking changes)
* `sigstore-sign`: 0.1.1 -> 0.2.0 (✓ API compatible changes)

### ⚠ `sigstore-types` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CheckpointSignature.name in /tmp/.tmp073c75/sigstore-rust/crates/sigstore-types/src/checkpoint.rs:62
  field CheckpointSignature.name in /tmp/.tmp073c75/sigstore-rust/crates/sigstore-types/src/checkpoint.rs:62
  field Checkpoint.signed_note_text in /tmp/.tmp073c75/sigstore-rust/crates/sigstore-types/src/checkpoint.rs:48
  field Checkpoint.signed_note_text in /tmp/.tmp073c75/sigstore-rust/crates/sigstore-types/src/checkpoint.rs:48

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_missing.ron

Failed in:
  struct sigstore_types::hash::HashOutput, previously in file /tmp/.tmpuo9L9k/sigstore-types/src/hash.rs:94
  struct sigstore_types::HashOutput, previously in file /tmp/.tmpuo9L9k/sigstore-types/src/hash.rs:94
  struct sigstore_types::hash::MessageImprint, previously in file /tmp/.tmpuo9L9k/sigstore-types/src/hash.rs:116
  struct sigstore_types::MessageImprint, previously in file /tmp/.tmpuo9L9k/sigstore-types/src/hash.rs:116
```

### ⚠ `sigstore-crypto` breaking changes

```text
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_missing.ron

Failed in:
  struct sigstore_crypto::checkpoint::SignedNote, previously in file /tmp/.tmpuo9L9k/sigstore-crypto/src/checkpoint.rs:70
  struct sigstore_crypto::SignedNote, previously in file /tmp/.tmpuo9L9k/sigstore-crypto/src/checkpoint.rs:70
  struct sigstore_crypto::checkpoint::NoteSignature, previously in file /tmp/.tmpuo9L9k/sigstore-crypto/src/checkpoint.rs:33
  struct sigstore_crypto::NoteSignature, previously in file /tmp/.tmpuo9L9k/sigstore-crypto/src/checkpoint.rs:33
  struct sigstore_crypto::checkpoint::LogCheckpoint, previously in file /tmp/.tmpuo9L9k/sigstore-crypto/src/checkpoint.rs:52
  struct sigstore_crypto::LogCheckpoint, previously in file /tmp/.tmpuo9L9k/sigstore-crypto/src/checkpoint.rs:52
```

### ⚠ `sigstore-merkle` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/function_missing.ron

Failed in:
  function sigstore_merkle::proof::verify_inclusion_proof_base64, previously in file /tmp/.tmpuo9L9k/sigstore-merkle/src/proof.rs:287
  function sigstore_merkle::verify_inclusion_proof_base64, previously in file /tmp/.tmpuo9L9k/sigstore-merkle/src/proof.rs:287
```

### ⚠ `sigstore-tsa` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/function_missing.ron

Failed in:
  function sigstore_tsa::parse::parse_timestamp, previously in file /tmp/.tmpuo9L9k/sigstore-tsa/src/parse.rs:128
  function sigstore_tsa::parse_timestamp, previously in file /tmp/.tmpuo9L9k/sigstore-tsa/src/parse.rs:128
  function sigstore_tsa::parse::parse_generalized_time, previously in file /tmp/.tmpuo9L9k/sigstore-tsa/src/parse.rs:151

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/module_missing.ron

Failed in:
  mod sigstore_tsa::parse, previously in file /tmp/.tmpuo9L9k/sigstore-tsa/src/parse.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_missing.ron

Failed in:
  struct sigstore_tsa::asn1::MessageImprint, previously in file /tmp/.tmpuo9L9k/sigstore-tsa/src/asn1.rs:116
  struct sigstore_tsa::MessageImprint, previously in file /tmp/.tmpuo9L9k/sigstore-tsa/src/asn1.rs:116
```

### ⚠ `sigstore-trust-root` breaking changes

```text
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_missing.ron

Failed in:
  struct sigstore_trust_root::trusted_root::LogId, previously in file /tmp/.tmpuo9L9k/sigstore-trust-root/src/trusted_root.rs:132
  struct sigstore_trust_root::trusted_root::Subject, previously in file /tmp/.tmpuo9L9k/sigstore-trust-root/src/trusted_root.rs:140
```

### ⚠ `sigstore-rekor` breaking changes

```text
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_missing.ron

Failed in:
  struct sigstore_rekor::entry::DsseSignature, previously in file /tmp/.tmpuo9L9k/sigstore-rekor/src/entry.rs:138
  struct sigstore_rekor::entry::InclusionProof, previously in file /tmp/.tmpuo9L9k/sigstore-rekor/src/entry.rs:49
```

### ⚠ `sigstore-verify` breaking changes

```text
--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/function_missing.ron

Failed in:
  function sigstore_verify::verify_with_trusted_root, previously in file /tmp/.tmpuo9L9k/sigstore-verify/src/verify.rs:382

--- failure function_parameter_count_changed: pub fn parameter count changed ---

Description:
A publicly-visible function now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/function_parameter_count_changed.ron

Failed in:
  sigstore_verify::verify now takes 4 parameters instead of 3, in /tmp/.tmp073c75/sigstore-rust/crates/sigstore-verify/src/verify.rs:375

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/inherent_method_missing.ron

Failed in:
  Verifier::new_with_trusted_root, previously in file /tmp/.tmpuo9L9k/sigstore-verify/src/verify.rs:161

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/method_parameter_count_changed.ron

Failed in:
  sigstore_verify::Verifier::new now takes 1 parameters instead of 0, in /tmp/.tmp073c75/sigstore-rust/crates/sigstore-verify/src/verify.rs:168
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `sigstore-types`

<blockquote>

## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-types-v0.1.1...sigstore-types-v0.2.0) - 2025-11-27

### Other

- more dead code removal
- format
- remove duplicated types, add license and readme files
</blockquote>

## `sigstore-crypto`

<blockquote>

## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-crypto-v0.1.1...sigstore-crypto-v0.2.0) - 2025-11-27

### Other

- format
- remove duplicated types, add license and readme files
</blockquote>

## `sigstore-merkle`

<blockquote>

## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-merkle-v0.1.1...sigstore-merkle-v0.2.0) - 2025-11-27

### Other

- remove unused function
- remove duplicated types, add license and readme files
</blockquote>

## `sigstore-tsa`

<blockquote>

## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-tsa-v0.1.1...sigstore-tsa-v0.2.0) - 2025-11-27

### Other

- require trust root in constructor, remove more unused code, update readme
- remove duplicated types, add license and readme files
</blockquote>

## `sigstore-trust-root`

<blockquote>

## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-trust-root-v0.1.1...sigstore-trust-root-v0.2.0) - 2025-11-27

### Other

- remove duplicated types, add license and readme files
</blockquote>

## `sigstore-rekor`

<blockquote>

## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-rekor-v0.1.1...sigstore-rekor-v0.2.0) - 2025-11-27

### Other

- remove duplicated types, add license and readme files
</blockquote>

## `sigstore-bundle`

<blockquote>

## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-bundle-v0.1.1...sigstore-bundle-v0.2.0) - 2025-11-27

### Other

- remove duplicated types, add license and readme files
</blockquote>

## `sigstore-fulcio`

<blockquote>

## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-fulcio-v0.1.1...sigstore-fulcio-v0.2.0) - 2025-11-27

### Other

- remove duplicated types, add license and readme files
</blockquote>

## `sigstore-oidc`

<blockquote>

## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-oidc-v0.1.1...sigstore-oidc-v0.2.0) - 2025-11-27

### Other

- remove duplicated types, add license and readme files
</blockquote>

## `sigstore-verify`

<blockquote>

## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-verify-v0.1.1...sigstore-verify-v0.2.0) - 2025-11-27

### Other

- require trust root in constructor, remove more unused code, update readme
- remove duplicated types, add license and readme files
</blockquote>

## `sigstore-sign`

<blockquote>

## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-sign-v0.1.1...sigstore-sign-v0.2.0) - 2025-11-27

### Other

- remove duplicated types, add license and readme files
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).