### PR TITLE
chore: release v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-bundle"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64",
  "hex",
@@ -1576,7 +1576,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-cache"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "chrono",
  "directories",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-conformance"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64",
  "hex",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-crypto"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -1630,7 +1630,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-fulcio"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64",
  "hex",
@@ -1648,7 +1648,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-merkle"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64",
  "hex",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-oidc"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64",
  "rand",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-rekor"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64",
  "hex",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-sign"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64",
  "chrono",
@@ -1717,7 +1717,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-trust-root"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64",
  "chrono",
@@ -1739,7 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-tsa"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-types"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64",
  "chrono",
@@ -1778,7 +1778,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-verify"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 license = "BSD-3-Clause"
 repository = "https://github.com/sigstore/sigultimate"
@@ -86,15 +86,15 @@ futures = "0.3"
 directories = "6.0"
 
 # Internal crates (path + version for publishing)
-sigstore-types = { path = "crates/sigstore-types", version = "0.2.0" }
-sigstore-crypto = { path = "crates/sigstore-crypto", version = "0.2.0" }
-sigstore-merkle = { path = "crates/sigstore-merkle", version = "0.2.0" }
-sigstore-tsa = { path = "crates/sigstore-tsa", version = "0.2.0" }
-sigstore-trust-root = { path = "crates/sigstore-trust-root", version = "0.2.0" }
-sigstore-bundle = { path = "crates/sigstore-bundle", version = "0.2.0" }
-sigstore-rekor = { path = "crates/sigstore-rekor", version = "0.2.0" }
-sigstore-fulcio = { path = "crates/sigstore-fulcio", version = "0.2.0" }
-sigstore-oidc = { path = "crates/sigstore-oidc", version = "0.2.0" }
-sigstore-cache = { path = "crates/sigstore-cache", version = "0.2.0" }
-sigstore-verify = { path = "crates/sigstore-verify", version = "0.2.0" }
-sigstore-sign = { path = "crates/sigstore-sign", version = "0.2.0" }
+sigstore-types = { path = "crates/sigstore-types", version = "0.3.0" }
+sigstore-crypto = { path = "crates/sigstore-crypto", version = "0.3.0" }
+sigstore-merkle = { path = "crates/sigstore-merkle", version = "0.3.0" }
+sigstore-tsa = { path = "crates/sigstore-tsa", version = "0.3.0" }
+sigstore-trust-root = { path = "crates/sigstore-trust-root", version = "0.3.0" }
+sigstore-bundle = { path = "crates/sigstore-bundle", version = "0.3.0" }
+sigstore-rekor = { path = "crates/sigstore-rekor", version = "0.3.0" }
+sigstore-fulcio = { path = "crates/sigstore-fulcio", version = "0.3.0" }
+sigstore-oidc = { path = "crates/sigstore-oidc", version = "0.3.0" }
+sigstore-cache = { path = "crates/sigstore-cache", version = "0.3.0" }
+sigstore-verify = { path = "crates/sigstore-verify", version = "0.3.0" }
+sigstore-sign = { path = "crates/sigstore-sign", version = "0.3.0" }

--- a/crates/sigstore-bundle/CHANGELOG.md
+++ b/crates/sigstore-bundle/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-bundle-v0.2.0...sigstore-bundle-v0.3.0) - 2025-11-28
+
+### Other
+
+- remove more types
+- remove certifactePem
+- unify certificate encoding
+- simplifications by only supporting v03 bundle creation
+- improve sign / verify flow, add conda specific test
+
 ## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-bundle-v0.1.1...sigstore-bundle-v0.2.0) - 2025-11-27
 
 ### Other

--- a/crates/sigstore-cache/CHANGELOG.md
+++ b/crates/sigstore-cache/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-cache-v0.2.0...sigstore-cache-v0.3.0) - 2025-11-28
+
+### Fixed
+
+- fix clippy warnings
+
+### Other
+
+- add simple separation for cache domains
+- add sigstore-cache

--- a/crates/sigstore-crypto/CHANGELOG.md
+++ b/crates/sigstore-crypto/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-crypto-v0.2.0...sigstore-crypto-v0.3.0) - 2025-11-28
+
+### Other
+
+- make all interfaces more type safe
+- remove more types
+- encode more certificates properly
+- unify certificate encoding
+- improve sign / verify flow, add conda specific test
+- more cleanup of functions
+
 ## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-crypto-v0.1.1...sigstore-crypto-v0.2.0) - 2025-11-27
 
 ### Other

--- a/crates/sigstore-fulcio/CHANGELOG.md
+++ b/crates/sigstore-fulcio/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-fulcio-v0.2.0...sigstore-fulcio-v0.3.0) - 2025-11-28
+
+### Fixed
+
+- fix clippy warnings
+
+### Other
+
+- add sigstore-cache
+- remove more types
+- encode more certificates properly
+
 ## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-fulcio-v0.1.1...sigstore-fulcio-v0.2.0) - 2025-11-27
 
 ### Other

--- a/crates/sigstore-merkle/CHANGELOG.md
+++ b/crates/sigstore-merkle/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-merkle-v0.2.0...sigstore-merkle-v0.3.0) - 2025-11-28
+
+### Other
+
+- more cleanup of functions
+
 ## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-merkle-v0.1.1...sigstore-merkle-v0.2.0) - 2025-11-27
 
 ### Other

--- a/crates/sigstore-rekor/CHANGELOG.md
+++ b/crates/sigstore-rekor/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-rekor-v0.2.0...sigstore-rekor-v0.3.0) - 2025-11-28
+
+### Other
+
+- add sigstore-cache
+- make all interfaces more type safe
+- remove more types
+- remove certifactePem
+- improve sign / verify flow, add conda specific test
+
 ## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-rekor-v0.1.1...sigstore-rekor-v0.2.0) - 2025-11-27
 
 ### Other

--- a/crates/sigstore-sign/CHANGELOG.md
+++ b/crates/sigstore-sign/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-sign-v0.2.0...sigstore-sign-v0.3.0) - 2025-11-28
+
+### Other
+
+- remove more types
+- encode more certificates properly
+- remove certifactePem
+- unify certificate encoding
+- simplifications by only supporting v03 bundle creation
+- improve sign / verify flow, add conda specific test
+- more cleanup of functions
+
 ## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-sign-v0.1.1...sigstore-sign-v0.2.0) - 2025-11-27
 
 ### Other

--- a/crates/sigstore-trust-root/CHANGELOG.md
+++ b/crates/sigstore-trust-root/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-trust-root-v0.2.0...sigstore-trust-root-v0.3.0) - 2025-11-28
+
+### Other
+
+- add staging trust root
+- make all interfaces more type safe
+- improve sign / verify flow, add conda specific test
+- more cleanup of functions
+
 ## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-trust-root-v0.1.1...sigstore-trust-root-v0.2.0) - 2025-11-27
 
 ### Other

--- a/crates/sigstore-tsa/CHANGELOG.md
+++ b/crates/sigstore-tsa/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-tsa-v0.2.0...sigstore-tsa-v0.3.0) - 2025-11-28
+
+### Other
+
+- remove more types
+- remove certifactePem
+- improve sign / verify flow, add conda specific test
+- more cleanup of functions
+
 ## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-tsa-v0.1.1...sigstore-tsa-v0.2.0) - 2025-11-27
 
 ### Other

--- a/crates/sigstore-types/CHANGELOG.md
+++ b/crates/sigstore-types/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-types-v0.2.0...sigstore-types-v0.3.0) - 2025-11-28
+
+### Other
+
+- make all interfaces more type safe
+- unify certificate encoding
+- improve sign / verify flow, add conda specific test
+- more cleanup of functions
+
 ## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-types-v0.1.1...sigstore-types-v0.2.0) - 2025-11-27
 
 ### Other

--- a/crates/sigstore-verify/CHANGELOG.md
+++ b/crates/sigstore-verify/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-verify-v0.2.0...sigstore-verify-v0.3.0) - 2025-11-28
+
+### Other
+
+- make all interfaces more type safe
+- remove more types
+- improve sign / verify flow, add conda specific test
+- more cleanup of functions
+- remove manual verification code and use webpki
+
 ## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-verify-v0.1.1...sigstore-verify-v0.2.0) - 2025-11-27
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `sigstore-types`: 0.2.0 -> 0.3.0 (✓ API compatible changes)
* `sigstore-crypto`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)
* `sigstore-merkle`: 0.2.0 -> 0.3.0 (✓ API compatible changes)
* `sigstore-tsa`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)
* `sigstore-trust-root`: 0.2.0 -> 0.3.0 (✓ API compatible changes)
* `sigstore-cache`: 0.2.0 -> 0.3.0
* `sigstore-rekor`: 0.2.0 -> 0.3.0 (✓ API compatible changes)
* `sigstore-bundle`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)
* `sigstore-oidc`: 0.2.0 -> 0.3.0
* `sigstore-fulcio`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)
* `sigstore-verify`: 0.2.0 -> 0.3.0 (✓ API compatible changes)
* `sigstore-sign`: 0.2.0 -> 0.3.0 (✓ API compatible changes)

### ⚠ `sigstore-crypto` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field CertificateInfo.public_key in /tmp/.tmpxx0x6a/sigstore-rust/crates/sigstore-crypto/src/x509.rs:33
  field CertificateInfo.public_key in /tmp/.tmpxx0x6a/sigstore-rust/crates/sigstore-crypto/src/x509.rs:33

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_variant_missing.ron

Failed in:
  variant KeyPair::EcdsaP384, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/signing.rs:183
  variant KeyPair::Ed25519, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/signing.rs:185
  variant KeyPair::Rsa, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/signing.rs:187
  variant KeyPair::EcdsaP384, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/signing.rs:183
  variant KeyPair::Ed25519, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/signing.rs:185
  variant KeyPair::Rsa, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/signing.rs:187

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/function_missing.ron

Failed in:
  function sigstore_crypto::x509::der_from_pem_any, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/x509.rs:210
  function sigstore_crypto::der_from_pem_any, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/x509.rs:210
  function sigstore_crypto::hash::sha512, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/hash.rs:22
  function sigstore_crypto::sha512, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/hash.rs:22
  function sigstore_crypto::x509::der_from_pem, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/x509.rs:195
  function sigstore_crypto::der_from_pem, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/x509.rs:195
  function sigstore_crypto::hash::sha384, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/hash.rs:14
  function sigstore_crypto::sha384, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/hash.rs:14

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/inherent_method_missing.ron

Failed in:
  VerificationKey::new, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/verification.rs:21
  VerificationKey::new, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/verification.rs:21
  KeyPair::generate_ecdsa_p384, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/signing.rs:201
  KeyPair::generate_ed25519, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/signing.rs:210
  KeyPair::sign_with_scheme, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/signing.rs:251
  KeyPair::public_key_to_der, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/signing.rs:320
  KeyPair::public_key_to_pem, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/signing.rs:356
  KeyPair::generate_ecdsa_p384, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/signing.rs:201
  KeyPair::generate_ed25519, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/signing.rs:210
  KeyPair::sign_with_scheme, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/signing.rs:251
  KeyPair::public_key_to_der, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/signing.rs:320
  KeyPair::public_key_to_pem, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/signing.rs:356

--- failure module_missing: pub module removed or renamed ---

Description:
A publicly-visible module cannot be imported by its prior path. A `pub use` may have been removed, or the module may have been renamed, removed, or made non-public.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/module_missing.ron

Failed in:
  mod sigstore_crypto::encoding, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/encoding.rs:1

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_missing.ron

Failed in:
  struct sigstore_crypto::encoding::SignatureBytes, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/encoding.rs:184
  struct sigstore_crypto::SignatureBytes, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/encoding.rs:184
  struct sigstore_crypto::signing::Signature, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/signing.rs:63
  struct sigstore_crypto::Signature, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/signing.rs:63
  struct sigstore_crypto::encoding::KeyHint, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/encoding.rs:217
  struct sigstore_crypto::KeyHint, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/encoding.rs:217
  struct sigstore_crypto::encoding::PublicKeySpki, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/encoding.rs:111
  struct sigstore_crypto::PublicKeySpki, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/encoding.rs:111
  struct sigstore_crypto::encoding::CertificateDer, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/encoding.rs:61
  struct sigstore_crypto::CertificateDer, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/encoding.rs:61
  struct sigstore_crypto::signing::PublicKeyPem, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/signing.rs:18
  struct sigstore_crypto::PublicKeyPem, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/signing.rs:18
  struct sigstore_crypto::encoding::DerBytes, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/encoding.rs:12
  struct sigstore_crypto::DerBytes, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/encoding.rs:12

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field public_key_bytes of struct CertificateInfo, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/x509.rs:32
  field public_key_bytes of struct CertificateInfo, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/x509.rs:32
  field bytes of struct VerificationKey, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/verification.rs:14
  field scheme of struct VerificationKey, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/verification.rs:16
  field bytes of struct VerificationKey, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/verification.rs:14
  field scheme of struct VerificationKey, previously in file /tmp/.tmpMExcAq/sigstore-crypto/src/verification.rs:16

--- failure struct_pub_field_now_doc_hidden: pub struct field is now #[doc(hidden)] ---

Description:
A pub field of a pub struct is now marked #[doc(hidden)] and is no longer part of the public API.
        ref: https://doc.rust-lang.org/rustdoc/write-documentation/the-doc-attribute.html#hidden
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_pub_field_now_doc_hidden.ron

Failed in:
  field VerificationKey.bytes in file /tmp/.tmpxx0x6a/sigstore-rust/crates/sigstore-crypto/src/verification.rs:14
  field VerificationKey.scheme in file /tmp/.tmpxx0x6a/sigstore-rust/crates/sigstore-crypto/src/verification.rs:14
  field VerificationKey.bytes in file /tmp/.tmpxx0x6a/sigstore-rust/crates/sigstore-crypto/src/verification.rs:14
  field VerificationKey.scheme in file /tmp/.tmpxx0x6a/sigstore-rust/crates/sigstore-crypto/src/verification.rs:14
```

### ⚠ `sigstore-tsa` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field VerifyOpts.tsa_certificates in /tmp/.tmpxx0x6a/sigstore-rust/crates/sigstore-tsa/src/verify.rs:43
  field VerifyOpts.tsa_certificates in /tmp/.tmpxx0x6a/sigstore-rust/crates/sigstore-tsa/src/verify.rs:43

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/enum_variant_missing.ron

Failed in:
  variant Error::OutsideValidityPeriod, previously in file /tmp/.tmpMExcAq/sigstore-tsa/src/error.rs:54
  variant Error::OutsideValidityPeriod, previously in file /tmp/.tmpMExcAq/sigstore-tsa/src/error.rs:54

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/function_missing.ron

Failed in:
  function sigstore_tsa::client::timestamp_sigstore, previously in file /tmp/.tmpMExcAq/sigstore-tsa/src/client.rs:110
  function sigstore_tsa::timestamp_sigstore, previously in file /tmp/.tmpMExcAq/sigstore-tsa/src/client.rs:110

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/inherent_method_missing.ron

Failed in:
  VerifyOpts::with_tsa_certificate, previously in file /tmp/.tmpMExcAq/sigstore-tsa/src/verify.rs:85
  VerifyOpts::with_tsa_validity, previously in file /tmp/.tmpMExcAq/sigstore-tsa/src/verify.rs:91
  VerifyOpts::with_tsa_certificate, previously in file /tmp/.tmpMExcAq/sigstore-tsa/src/verify.rs:85
  VerifyOpts::with_tsa_validity, previously in file /tmp/.tmpMExcAq/sigstore-tsa/src/verify.rs:91
  TimestampClient::timestamp, previously in file /tmp/.tmpMExcAq/sigstore-tsa/src/client.rs:41
  TimestampClient::timestamp_sha256, previously in file /tmp/.tmpMExcAq/sigstore-tsa/src/client.rs:94
  TimestampClient::timestamp_sha384, previously in file /tmp/.tmpMExcAq/sigstore-tsa/src/client.rs:99
  TimestampClient::timestamp_sha512, previously in file /tmp/.tmpMExcAq/sigstore-tsa/src/client.rs:104
  TimestampClient::timestamp, previously in file /tmp/.tmpMExcAq/sigstore-tsa/src/client.rs:41
  TimestampClient::timestamp_sha256, previously in file /tmp/.tmpMExcAq/sigstore-tsa/src/client.rs:94
  TimestampClient::timestamp_sha384, previously in file /tmp/.tmpMExcAq/sigstore-tsa/src/client.rs:99
  TimestampClient::timestamp_sha512, previously in file /tmp/.tmpMExcAq/sigstore-tsa/src/client.rs:104

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field tsa_certificate of struct VerifyOpts, previously in file /tmp/.tmpMExcAq/sigstore-tsa/src/verify.rs:42
  field tsa_valid_for of struct VerifyOpts, previously in file /tmp/.tmpMExcAq/sigstore-tsa/src/verify.rs:46
  field tsa_certificate of struct VerifyOpts, previously in file /tmp/.tmpMExcAq/sigstore-tsa/src/verify.rs:42
  field tsa_valid_for of struct VerifyOpts, previously in file /tmp/.tmpMExcAq/sigstore-tsa/src/verify.rs:46
```

### ⚠ `sigstore-bundle` breaking changes

```text
--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_missing.ron

Failed in:
  struct sigstore_bundle::builder::BundleBuilder, previously in file /tmp/.tmpMExcAq/sigstore-bundle/src/builder.rs:15
  struct sigstore_bundle::BundleBuilder, previously in file /tmp/.tmpMExcAq/sigstore-bundle/src/builder.rs:15
```

### ⚠ `sigstore-fulcio` breaking changes

```text
--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/method_parameter_count_changed.ron

Failed in:
  sigstore_fulcio::client::FulcioClient::create_signing_certificate now takes 3 parameters instead of 4, in /tmp/.tmpxx0x6a/sigstore-rust/crates/sigstore-fulcio/src/client.rs:116
  sigstore_fulcio::FulcioClient::create_signing_certificate now takes 3 parameters instead of 4, in /tmp/.tmpxx0x6a/sigstore-rust/crates/sigstore-fulcio/src/client.rs:116
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `sigstore-types`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-types-v0.2.0...sigstore-types-v0.3.0) - 2025-11-28

### Other

- make all interfaces more type safe
- unify certificate encoding
- improve sign / verify flow, add conda specific test
- more cleanup of functions
</blockquote>

## `sigstore-crypto`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-crypto-v0.2.0...sigstore-crypto-v0.3.0) - 2025-11-28

### Other

- make all interfaces more type safe
- remove more types
- encode more certificates properly
- unify certificate encoding
- improve sign / verify flow, add conda specific test
- more cleanup of functions
</blockquote>

## `sigstore-merkle`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-merkle-v0.2.0...sigstore-merkle-v0.3.0) - 2025-11-28

### Other

- more cleanup of functions
</blockquote>

## `sigstore-tsa`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-tsa-v0.2.0...sigstore-tsa-v0.3.0) - 2025-11-28

### Other

- remove more types
- remove certifactePem
- improve sign / verify flow, add conda specific test
- more cleanup of functions
</blockquote>

## `sigstore-trust-root`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-trust-root-v0.2.0...sigstore-trust-root-v0.3.0) - 2025-11-28

### Other

- add staging trust root
- make all interfaces more type safe
- improve sign / verify flow, add conda specific test
- more cleanup of functions
</blockquote>

## `sigstore-cache`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-cache-v0.2.0...sigstore-cache-v0.3.0) - 2025-11-28

### Fixed

- fix clippy warnings

### Other

- add simple separation for cache domains
- add sigstore-cache
</blockquote>

## `sigstore-rekor`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-rekor-v0.2.0...sigstore-rekor-v0.3.0) - 2025-11-28

### Other

- add sigstore-cache
- make all interfaces more type safe
- remove more types
- remove certifactePem
- improve sign / verify flow, add conda specific test
</blockquote>

## `sigstore-bundle`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-bundle-v0.2.0...sigstore-bundle-v0.3.0) - 2025-11-28

### Other

- remove more types
- remove certifactePem
- unify certificate encoding
- simplifications by only supporting v03 bundle creation
- improve sign / verify flow, add conda specific test
</blockquote>

## `sigstore-oidc`

<blockquote>

## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-oidc-v0.1.1...sigstore-oidc-v0.2.0) - 2025-11-27

### Other

- remove duplicated types, add license and readme files
</blockquote>

## `sigstore-fulcio`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-fulcio-v0.2.0...sigstore-fulcio-v0.3.0) - 2025-11-28

### Fixed

- fix clippy warnings

### Other

- add sigstore-cache
- remove more types
- encode more certificates properly
</blockquote>

## `sigstore-verify`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-verify-v0.2.0...sigstore-verify-v0.3.0) - 2025-11-28

### Other

- make all interfaces more type safe
- remove more types
- improve sign / verify flow, add conda specific test
- more cleanup of functions
- remove manual verification code and use webpki
</blockquote>

## `sigstore-sign`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-sign-v0.2.0...sigstore-sign-v0.3.0) - 2025-11-28

### Other

- remove more types
- encode more certificates properly
- remove certifactePem
- unify certificate encoding
- simplifications by only supporting v03 bundle creation
- improve sign / verify flow, add conda specific test
- more cleanup of functions
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).