### PR TITLE
chore: release v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1560,7 +1560,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-bundle"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "hex",
@@ -1576,7 +1576,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-cache"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "directories",
@@ -1588,7 +1588,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-conformance"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "hex",
@@ -1609,7 +1609,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-crypto"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -1630,7 +1630,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-fulcio"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "hex",
@@ -1648,7 +1648,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-merkle"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "hex",
@@ -1662,7 +1662,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-oidc"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "rand",
@@ -1678,7 +1678,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-rekor"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "hex",
@@ -1696,7 +1696,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-sign"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "chrono",
@@ -1717,7 +1717,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-trust-root"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "chrono",
@@ -1739,7 +1739,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-tsa"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-types"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "chrono",
@@ -1778,7 +1778,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-verify"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 license = "BSD-3-Clause"
 repository = "https://github.com/sigstore/sigultimate"
@@ -86,15 +86,15 @@ futures = "0.3"
 directories = "6.0"
 
 # Internal crates (path + version for publishing)
-sigstore-types = { path = "crates/sigstore-types", version = "0.3.0" }
-sigstore-crypto = { path = "crates/sigstore-crypto", version = "0.3.0" }
-sigstore-merkle = { path = "crates/sigstore-merkle", version = "0.3.0" }
-sigstore-tsa = { path = "crates/sigstore-tsa", version = "0.3.0" }
-sigstore-trust-root = { path = "crates/sigstore-trust-root", version = "0.3.0" }
-sigstore-bundle = { path = "crates/sigstore-bundle", version = "0.3.0" }
-sigstore-rekor = { path = "crates/sigstore-rekor", version = "0.3.0" }
-sigstore-fulcio = { path = "crates/sigstore-fulcio", version = "0.3.0" }
-sigstore-oidc = { path = "crates/sigstore-oidc", version = "0.3.0" }
-sigstore-cache = { path = "crates/sigstore-cache", version = "0.3.0" }
-sigstore-verify = { path = "crates/sigstore-verify", version = "0.3.0" }
-sigstore-sign = { path = "crates/sigstore-sign", version = "0.3.0" }
+sigstore-types = { path = "crates/sigstore-types", version = "0.4.0" }
+sigstore-crypto = { path = "crates/sigstore-crypto", version = "0.4.0" }
+sigstore-merkle = { path = "crates/sigstore-merkle", version = "0.4.0" }
+sigstore-tsa = { path = "crates/sigstore-tsa", version = "0.4.0" }
+sigstore-trust-root = { path = "crates/sigstore-trust-root", version = "0.4.0" }
+sigstore-bundle = { path = "crates/sigstore-bundle", version = "0.4.0" }
+sigstore-rekor = { path = "crates/sigstore-rekor", version = "0.4.0" }
+sigstore-fulcio = { path = "crates/sigstore-fulcio", version = "0.4.0" }
+sigstore-oidc = { path = "crates/sigstore-oidc", version = "0.4.0" }
+sigstore-cache = { path = "crates/sigstore-cache", version = "0.4.0" }
+sigstore-verify = { path = "crates/sigstore-verify", version = "0.4.0" }
+sigstore-sign = { path = "crates/sigstore-sign", version = "0.4.0" }

--- a/crates/sigstore-crypto/CHANGELOG.md
+++ b/crates/sigstore-crypto/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-crypto-v0.3.0...sigstore-crypto-v0.4.0) - 2025-11-28
+
+### Other
+
+- introduce new artifact api
+
 ## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-crypto-v0.2.0...sigstore-crypto-v0.3.0) - 2025-11-28
 
 ### Other

--- a/crates/sigstore-sign/CHANGELOG.md
+++ b/crates/sigstore-sign/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-sign-v0.3.0...sigstore-sign-v0.4.0) - 2025-11-28
+
+### Other
+
+- introduce new artifact api
+
 ## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-sign-v0.2.0...sigstore-sign-v0.3.0) - 2025-11-28
 
 ### Other

--- a/crates/sigstore-types/CHANGELOG.md
+++ b/crates/sigstore-types/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-types-v0.3.0...sigstore-types-v0.4.0) - 2025-11-28
+
+### Other
+
+- add missing file
+- introduce new artifact api
+
 ## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-types-v0.2.0...sigstore-types-v0.3.0) - 2025-11-28
 
 ### Other

--- a/crates/sigstore-verify/CHANGELOG.md
+++ b/crates/sigstore-verify/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-verify-v0.3.0...sigstore-verify-v0.4.0) - 2025-11-28
+
+### Other
+
+- introduce new artifact api
+
 ## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-verify-v0.2.0...sigstore-verify-v0.3.0) - 2025-11-28
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `sigstore-types`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `sigstore-crypto`: 0.3.0 -> 0.4.0 (✓ API compatible changes)
* `sigstore-merkle`: 0.3.0 -> 0.4.0
* `sigstore-tsa`: 0.3.0 -> 0.4.0
* `sigstore-trust-root`: 0.3.0 -> 0.4.0
* `sigstore-cache`: 0.3.0 -> 0.4.0
* `sigstore-rekor`: 0.3.0 -> 0.4.0
* `sigstore-bundle`: 0.3.0 -> 0.4.0
* `sigstore-oidc`: 0.3.0 -> 0.4.0
* `sigstore-fulcio`: 0.3.0 -> 0.4.0
* `sigstore-verify`: 0.3.0 -> 0.4.0 (⚠ API breaking changes)
* `sigstore-sign`: 0.3.0 -> 0.4.0 (✓ API compatible changes)

### ⚠ `sigstore-verify` breaking changes

```text
--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/inherent_method_missing.ron

Failed in:
  VerificationPolicy::skip_artifact_hash, previously in file /tmp/.tmpYT80KZ/sigstore-verify/src/verify.rs:103

--- failure struct_pub_field_missing: pub struct's pub field removed or renamed ---

Description:
A publicly-visible struct has at least one public field that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/struct_pub_field_missing.ron

Failed in:
  field skip_artifact_hash of struct VerificationPolicy, previously in file /tmp/.tmpYT80KZ/sigstore-verify/src/verify.rs:30
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `sigstore-types`

<blockquote>

## [0.4.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-types-v0.3.0...sigstore-types-v0.4.0) - 2025-11-28

### Other

- add missing file
- introduce new artifact api
</blockquote>

## `sigstore-crypto`

<blockquote>

## [0.4.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-crypto-v0.3.0...sigstore-crypto-v0.4.0) - 2025-11-28

### Other

- introduce new artifact api
</blockquote>

## `sigstore-merkle`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-merkle-v0.2.0...sigstore-merkle-v0.3.0) - 2025-11-28

### Other

- more cleanup of functions
</blockquote>

## `sigstore-tsa`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-tsa-v0.2.0...sigstore-tsa-v0.3.0) - 2025-11-28

### Other

- remove more types
- remove certifactePem
- improve sign / verify flow, add conda specific test
- more cleanup of functions
</blockquote>

## `sigstore-trust-root`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-trust-root-v0.2.0...sigstore-trust-root-v0.3.0) - 2025-11-28

### Other

- add staging trust root
- make all interfaces more type safe
- improve sign / verify flow, add conda specific test
- more cleanup of functions
</blockquote>

## `sigstore-cache`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-cache-v0.2.0...sigstore-cache-v0.3.0) - 2025-11-28

### Fixed

- fix clippy warnings

### Other

- add simple separation for cache domains
- add sigstore-cache
</blockquote>

## `sigstore-rekor`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-rekor-v0.2.0...sigstore-rekor-v0.3.0) - 2025-11-28

### Other

- add sigstore-cache
- make all interfaces more type safe
- remove more types
- remove certifactePem
- improve sign / verify flow, add conda specific test
</blockquote>

## `sigstore-bundle`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-bundle-v0.2.0...sigstore-bundle-v0.3.0) - 2025-11-28

### Other

- remove more types
- remove certifactePem
- unify certificate encoding
- simplifications by only supporting v03 bundle creation
- improve sign / verify flow, add conda specific test
</blockquote>

## `sigstore-oidc`

<blockquote>

## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-oidc-v0.1.1...sigstore-oidc-v0.2.0) - 2025-11-27

### Other

- remove duplicated types, add license and readme files
</blockquote>

## `sigstore-fulcio`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-fulcio-v0.2.0...sigstore-fulcio-v0.3.0) - 2025-11-28

### Fixed

- fix clippy warnings

### Other

- add sigstore-cache
- remove more types
- encode more certificates properly
</blockquote>

## `sigstore-verify`

<blockquote>

## [0.4.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-verify-v0.3.0...sigstore-verify-v0.4.0) - 2025-11-28

### Other

- introduce new artifact api
</blockquote>

## `sigstore-sign`

<blockquote>

## [0.4.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-sign-v0.3.0...sigstore-sign-v0.4.0) - 2025-11-28

### Other

- introduce new artifact api
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).