### PR TITLE
chore: release v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1461,7 +1461,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-bundle"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64",
  "hex",
@@ -1477,7 +1477,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-cache"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "directories",
@@ -1489,7 +1489,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-conformance"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64",
  "hex",
@@ -1510,7 +1510,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-crypto"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -1531,7 +1531,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-fulcio"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64",
  "hex",
@@ -1549,7 +1549,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-merkle"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64",
  "hex",
@@ -1563,7 +1563,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-oidc"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64",
  "rand",
@@ -1579,7 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-rekor"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64",
  "hex",
@@ -1597,7 +1597,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-sign"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64",
  "chrono",
@@ -1619,7 +1619,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-trust-root"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64",
  "chrono",
@@ -1641,7 +1641,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-tsa"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -1667,7 +1667,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-types"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64",
  "chrono",
@@ -1680,7 +1680,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-verify"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "BSD-3-Clause"
 repository = "https://github.com/wolfv/sigstore-rust"
@@ -86,15 +86,15 @@ futures = "0.3"
 directories = "6.0"
 
 # Internal crates (path + version for publishing)
-sigstore-types = { path = "crates/sigstore-types", version = "0.4.0" }
-sigstore-crypto = { path = "crates/sigstore-crypto", version = "0.4.0" }
-sigstore-merkle = { path = "crates/sigstore-merkle", version = "0.4.0" }
-sigstore-tsa = { path = "crates/sigstore-tsa", version = "0.4.0" }
-sigstore-trust-root = { path = "crates/sigstore-trust-root", version = "0.4.0" }
-sigstore-bundle = { path = "crates/sigstore-bundle", version = "0.4.0" }
-sigstore-rekor = { path = "crates/sigstore-rekor", version = "0.4.0" }
-sigstore-fulcio = { path = "crates/sigstore-fulcio", version = "0.4.0" }
-sigstore-oidc = { path = "crates/sigstore-oidc", version = "0.4.0" }
-sigstore-cache = { path = "crates/sigstore-cache", version = "0.4.0" }
-sigstore-verify = { path = "crates/sigstore-verify", version = "0.4.0" }
-sigstore-sign = { path = "crates/sigstore-sign", version = "0.4.0" }
+sigstore-types = { path = "crates/sigstore-types", version = "0.5.0" }
+sigstore-crypto = { path = "crates/sigstore-crypto", version = "0.5.0" }
+sigstore-merkle = { path = "crates/sigstore-merkle", version = "0.5.0" }
+sigstore-tsa = { path = "crates/sigstore-tsa", version = "0.5.0" }
+sigstore-trust-root = { path = "crates/sigstore-trust-root", version = "0.5.0" }
+sigstore-bundle = { path = "crates/sigstore-bundle", version = "0.5.0" }
+sigstore-rekor = { path = "crates/sigstore-rekor", version = "0.5.0" }
+sigstore-fulcio = { path = "crates/sigstore-fulcio", version = "0.5.0" }
+sigstore-oidc = { path = "crates/sigstore-oidc", version = "0.5.0" }
+sigstore-cache = { path = "crates/sigstore-cache", version = "0.5.0" }
+sigstore-verify = { path = "crates/sigstore-verify", version = "0.5.0" }
+sigstore-sign = { path = "crates/sigstore-sign", version = "0.5.0" }

--- a/crates/sigstore-bundle/CHANGELOG.md
+++ b/crates/sigstore-bundle/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-bundle-v0.4.0...sigstore-bundle-v0.5.0) - 2025-12-01
+
+### Added
+
+- Add SigningConfig support and V2 bundle fixes ([#6](https://github.com/wolfv/sigstore-rust/pull/6))
+
 ## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-bundle-v0.2.0...sigstore-bundle-v0.3.0) - 2025-11-28
 
 ### Other

--- a/crates/sigstore-rekor/CHANGELOG.md
+++ b/crates/sigstore-rekor/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-rekor-v0.4.0...sigstore-rekor-v0.5.0) - 2025-12-01
+
+### Added
+
+- Add SigningConfig support and V2 bundle fixes ([#6](https://github.com/wolfv/sigstore-rust/pull/6))
+
 ## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-rekor-v0.2.0...sigstore-rekor-v0.3.0) - 2025-11-28
 
 ### Other

--- a/crates/sigstore-sign/CHANGELOG.md
+++ b/crates/sigstore-sign/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-sign-v0.4.0...sigstore-sign-v0.5.0) - 2025-12-01
+
+### Added
+
+- Add SigningConfig support and V2 bundle fixes ([#6](https://github.com/wolfv/sigstore-rust/pull/6))
+
 ## [0.4.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-sign-v0.3.0...sigstore-sign-v0.4.0) - 2025-11-28
 
 ### Other

--- a/crates/sigstore-trust-root/CHANGELOG.md
+++ b/crates/sigstore-trust-root/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-trust-root-v0.4.0...sigstore-trust-root-v0.5.0) - 2025-12-01
+
+### Added
+
+- Add SigningConfig support and V2 bundle fixes ([#6](https://github.com/wolfv/sigstore-rust/pull/6))
+
 ## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-trust-root-v0.2.0...sigstore-trust-root-v0.3.0) - 2025-11-28
 
 ### Other

--- a/crates/sigstore-verify/CHANGELOG.md
+++ b/crates/sigstore-verify/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-verify-v0.4.0...sigstore-verify-v0.5.0) - 2025-12-01
+
+### Added
+
+- Add SigningConfig support and V2 bundle fixes ([#6](https://github.com/wolfv/sigstore-rust/pull/6))
+
 ## [0.4.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-verify-v0.3.0...sigstore-verify-v0.4.0) - 2025-11-28
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `sigstore-types`: 0.4.0 -> 0.5.0
* `sigstore-crypto`: 0.4.0 -> 0.5.0
* `sigstore-merkle`: 0.4.0 -> 0.5.0
* `sigstore-tsa`: 0.4.0 -> 0.5.0
* `sigstore-trust-root`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)
* `sigstore-cache`: 0.4.0 -> 0.5.0
* `sigstore-rekor`: 0.4.0 -> 0.5.0 (✓ API compatible changes)
* `sigstore-bundle`: 0.4.0 -> 0.5.0 (✓ API compatible changes)
* `sigstore-oidc`: 0.4.0 -> 0.5.0
* `sigstore-fulcio`: 0.4.0 -> 0.5.0
* `sigstore-verify`: 0.4.0 -> 0.5.0 (✓ API compatible changes)
* `sigstore-sign`: 0.4.0 -> 0.5.0 (⚠ API breaking changes)

### ⚠ `sigstore-trust-root` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field TufConfig.offline in /tmp/.tmpjEcX6w/sigstore-rust/crates/sigstore-trust-root/src/tuf.rs:60
  field TufConfig.offline in /tmp/.tmpjEcX6w/sigstore-rust/crates/sigstore-trust-root/src/tuf.rs:60
```

### ⚠ `sigstore-sign` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.45.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field SigningConfig.rekor_api_version in /tmp/.tmpjEcX6w/sigstore-rust/crates/sigstore-sign/src/sign.rs:32
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `sigstore-types`

<blockquote>

## [0.4.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-types-v0.3.0...sigstore-types-v0.4.0) - 2025-11-28

### Other

- add missing file
- introduce new artifact api
</blockquote>

## `sigstore-crypto`

<blockquote>

## [0.4.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-crypto-v0.3.0...sigstore-crypto-v0.4.0) - 2025-11-28

### Other

- introduce new artifact api
</blockquote>

## `sigstore-merkle`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-merkle-v0.2.0...sigstore-merkle-v0.3.0) - 2025-11-28

### Other

- more cleanup of functions
</blockquote>

## `sigstore-tsa`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-tsa-v0.2.0...sigstore-tsa-v0.3.0) - 2025-11-28

### Other

- remove more types
- remove certifactePem
- improve sign / verify flow, add conda specific test
- more cleanup of functions
</blockquote>

## `sigstore-trust-root`

<blockquote>

## [0.5.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-trust-root-v0.4.0...sigstore-trust-root-v0.5.0) - 2025-12-01

### Added

- Add SigningConfig support and V2 bundle fixes ([#6](https://github.com/wolfv/sigstore-rust/pull/6))
</blockquote>

## `sigstore-cache`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-cache-v0.2.0...sigstore-cache-v0.3.0) - 2025-11-28

### Fixed

- fix clippy warnings

### Other

- add simple separation for cache domains
- add sigstore-cache
</blockquote>

## `sigstore-rekor`

<blockquote>

## [0.5.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-rekor-v0.4.0...sigstore-rekor-v0.5.0) - 2025-12-01

### Added

- Add SigningConfig support and V2 bundle fixes ([#6](https://github.com/wolfv/sigstore-rust/pull/6))
</blockquote>

## `sigstore-bundle`

<blockquote>

## [0.5.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-bundle-v0.4.0...sigstore-bundle-v0.5.0) - 2025-12-01

### Added

- Add SigningConfig support and V2 bundle fixes ([#6](https://github.com/wolfv/sigstore-rust/pull/6))
</blockquote>

## `sigstore-oidc`

<blockquote>

## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-oidc-v0.1.1...sigstore-oidc-v0.2.0) - 2025-11-27

### Other

- remove duplicated types, add license and readme files
</blockquote>

## `sigstore-fulcio`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-fulcio-v0.2.0...sigstore-fulcio-v0.3.0) - 2025-11-28

### Fixed

- fix clippy warnings

### Other

- add sigstore-cache
- remove more types
- encode more certificates properly
</blockquote>

## `sigstore-verify`

<blockquote>

## [0.5.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-verify-v0.4.0...sigstore-verify-v0.5.0) - 2025-12-01

### Added

- Add SigningConfig support and V2 bundle fixes ([#6](https://github.com/wolfv/sigstore-rust/pull/6))
</blockquote>

## `sigstore-sign`

<blockquote>

## [0.5.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-sign-v0.4.0...sigstore-sign-v0.5.0) - 2025-12-01

### Added

- Add SigningConfig support and V2 bundle fixes ([#6](https://github.com/wolfv/sigstore-rust/pull/6))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).