### PR TITLE
chore: release v0.6.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1681,7 +1681,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-bundle"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "base64",
  "hex",
@@ -1697,7 +1697,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-cache"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "chrono",
  "directories",
@@ -1709,7 +1709,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-conformance"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "base64",
  "hex",
@@ -1730,7 +1730,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-crypto"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -1751,7 +1751,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-fulcio"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "base64",
  "hex",
@@ -1769,7 +1769,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-merkle"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "base64",
  "hex",
@@ -1783,7 +1783,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-oidc"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "ambient-id",
  "base64",
@@ -1800,7 +1800,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-rekor"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "base64",
  "hex",
@@ -1818,7 +1818,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-sign"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "base64",
  "chrono",
@@ -1840,7 +1840,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-trust-root"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "base64",
  "chrono",
@@ -1862,7 +1862,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-tsa"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -1888,7 +1888,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-types"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "base64",
  "chrono",
@@ -1901,7 +1901,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-verify"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.6.1"
 edition = "2021"
 license = "BSD-3-Clause"
 repository = "https://github.com/wolfv/sigstore-rust"
@@ -87,15 +87,15 @@ futures = "0.3"
 directories = "6.0"
 
 # Internal crates (path + version for publishing)
-sigstore-types = { path = "crates/sigstore-types", version = "0.6.0" }
-sigstore-crypto = { path = "crates/sigstore-crypto", version = "0.6.0" }
-sigstore-merkle = { path = "crates/sigstore-merkle", version = "0.6.0" }
-sigstore-tsa = { path = "crates/sigstore-tsa", version = "0.6.0" }
-sigstore-trust-root = { path = "crates/sigstore-trust-root", version = "0.6.0" }
-sigstore-bundle = { path = "crates/sigstore-bundle", version = "0.6.0" }
-sigstore-rekor = { path = "crates/sigstore-rekor", version = "0.6.0" }
-sigstore-fulcio = { path = "crates/sigstore-fulcio", version = "0.6.0" }
-sigstore-oidc = { path = "crates/sigstore-oidc", version = "0.6.0" }
-sigstore-cache = { path = "crates/sigstore-cache", version = "0.6.0" }
-sigstore-verify = { path = "crates/sigstore-verify", version = "0.6.0" }
-sigstore-sign = { path = "crates/sigstore-sign", version = "0.6.0" }
+sigstore-types = { path = "crates/sigstore-types", version = "0.6.1" }
+sigstore-crypto = { path = "crates/sigstore-crypto", version = "0.6.1" }
+sigstore-merkle = { path = "crates/sigstore-merkle", version = "0.6.1" }
+sigstore-tsa = { path = "crates/sigstore-tsa", version = "0.6.1" }
+sigstore-trust-root = { path = "crates/sigstore-trust-root", version = "0.6.1" }
+sigstore-bundle = { path = "crates/sigstore-bundle", version = "0.6.1" }
+sigstore-rekor = { path = "crates/sigstore-rekor", version = "0.6.1" }
+sigstore-fulcio = { path = "crates/sigstore-fulcio", version = "0.6.1" }
+sigstore-oidc = { path = "crates/sigstore-oidc", version = "0.6.1" }
+sigstore-cache = { path = "crates/sigstore-cache", version = "0.6.1" }
+sigstore-verify = { path = "crates/sigstore-verify", version = "0.6.1" }
+sigstore-sign = { path = "crates/sigstore-sign", version = "0.6.1" }

--- a/crates/sigstore-oidc/CHANGELOG.md
+++ b/crates/sigstore-oidc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-oidc-v0.6.0...sigstore-oidc-v0.6.1) - 2026-01-26
+
+### Added
+
+- use `ambient-id` to detect tokens in CI pipelines ([#36](https://github.com/prefix-dev/sigstore-rust/pull/36))
+
 ## [0.2.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-oidc-v0.1.1...sigstore-oidc-v0.2.0) - 2025-11-27
 
 ### Other

--- a/crates/sigstore-sign/CHANGELOG.md
+++ b/crates/sigstore-sign/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-sign-v0.6.0...sigstore-sign-v0.6.1) - 2026-01-26
+
+### Added
+
+- use `ambient-id` to detect tokens in CI pipelines ([#36](https://github.com/prefix-dev/sigstore-rust/pull/36))
+
 ## [0.6.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-sign-v0.5.0...sigstore-sign-v0.6.0) - 2025-12-08
 
 ### Other

--- a/crates/sigstore-verify/CHANGELOG.md
+++ b/crates/sigstore-verify/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-verify-v0.6.0...sigstore-verify-v0.6.1) - 2026-01-26
+
+### Fixed
+
+- *(conformance)* add verification with key ([#41](https://github.com/prefix-dev/sigstore-rust/pull/41))
+
 ## [0.6.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-verify-v0.5.0...sigstore-verify-v0.6.0) - 2025-12-08
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `sigstore-types`: 0.6.0 -> 0.6.1
* `sigstore-crypto`: 0.6.0 -> 0.6.1
* `sigstore-merkle`: 0.6.0 -> 0.6.1
* `sigstore-tsa`: 0.6.0 -> 0.6.1
* `sigstore-trust-root`: 0.6.0 -> 0.6.1
* `sigstore-cache`: 0.6.0 -> 0.6.1
* `sigstore-rekor`: 0.6.0 -> 0.6.1
* `sigstore-bundle`: 0.6.0 -> 0.6.1
* `sigstore-oidc`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `sigstore-fulcio`: 0.6.0 -> 0.6.1
* `sigstore-verify`: 0.6.0 -> 0.6.1 (✓ API compatible changes)
* `sigstore-sign`: 0.6.0 -> 0.6.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `sigstore-types`

<blockquote>

## [0.6.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-types-v0.5.0...sigstore-types-v0.6.0) - 2025-12-08

### Other

- improve types and add interop test workflow ([#9](https://github.com/wolfv/sigstore-rust/pull/9))
</blockquote>

## `sigstore-crypto`

<blockquote>

## [0.4.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-crypto-v0.3.0...sigstore-crypto-v0.4.0) - 2025-11-28

### Other

- introduce new artifact api
</blockquote>

## `sigstore-merkle`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-merkle-v0.2.0...sigstore-merkle-v0.3.0) - 2025-11-28

### Other

- more cleanup of functions
</blockquote>

## `sigstore-tsa`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-tsa-v0.2.0...sigstore-tsa-v0.3.0) - 2025-11-28

### Other

- remove more types
- remove certifactePem
- improve sign / verify flow, add conda specific test
- more cleanup of functions
</blockquote>

## `sigstore-trust-root`

<blockquote>

## [0.5.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-trust-root-v0.4.0...sigstore-trust-root-v0.5.0) - 2025-12-01

### Added

- Add SigningConfig support and V2 bundle fixes ([#6](https://github.com/wolfv/sigstore-rust/pull/6))
</blockquote>

## `sigstore-cache`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-cache-v0.2.0...sigstore-cache-v0.3.0) - 2025-11-28

### Fixed

- fix clippy warnings

### Other

- add simple separation for cache domains
- add sigstore-cache
</blockquote>

## `sigstore-rekor`

<blockquote>

## [0.5.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-rekor-v0.4.0...sigstore-rekor-v0.5.0) - 2025-12-01

### Added

- Add SigningConfig support and V2 bundle fixes ([#6](https://github.com/wolfv/sigstore-rust/pull/6))
</blockquote>

## `sigstore-bundle`

<blockquote>

## [0.6.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-bundle-v0.5.0...sigstore-bundle-v0.6.0) - 2025-12-08

### Added

- add fuzzing tests ([#13](https://github.com/wolfv/sigstore-rust/pull/13))

### Other

- improve types and add interop test workflow ([#9](https://github.com/wolfv/sigstore-rust/pull/9))
</blockquote>

## `sigstore-oidc`

<blockquote>

## [0.6.1](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-oidc-v0.6.0...sigstore-oidc-v0.6.1) - 2026-01-26

### Added

- use `ambient-id` to detect tokens in CI pipelines ([#36](https://github.com/prefix-dev/sigstore-rust/pull/36))
</blockquote>

## `sigstore-fulcio`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-fulcio-v0.2.0...sigstore-fulcio-v0.3.0) - 2025-11-28

### Fixed

- fix clippy warnings

### Other

- add sigstore-cache
- remove more types
- encode more certificates properly
</blockquote>

## `sigstore-verify`

<blockquote>

## [0.6.1](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-verify-v0.6.0...sigstore-verify-v0.6.1) - 2026-01-26

### Fixed

- *(conformance)* add verification with key ([#41](https://github.com/prefix-dev/sigstore-rust/pull/41))
</blockquote>

## `sigstore-sign`

<blockquote>

## [0.6.1](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-sign-v0.6.0...sigstore-sign-v0.6.1) - 2026-01-26

### Added

- use `ambient-id` to detect tokens in CI pipelines ([#36](https://github.com/prefix-dev/sigstore-rust/pull/36))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).