### PR TITLE
chore: release v0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-bundle"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "base64",
  "hex",
@@ -1928,7 +1928,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-cache"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "chrono",
  "directories",
@@ -1940,7 +1940,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-conformance"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "base64",
  "hex",
@@ -1961,7 +1961,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-crypto"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -1982,7 +1982,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-fulcio"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "base64",
  "hex",
@@ -2000,7 +2000,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-merkle"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "base64",
  "hex",
@@ -2014,7 +2014,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-oidc"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "ambient-id",
  "base64",
@@ -2031,7 +2031,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-rekor"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "base64",
  "hex",
@@ -2049,7 +2049,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-sign"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "base64",
  "chrono",
@@ -2071,7 +2071,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-trust-root"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "base64",
  "chrono",
@@ -2093,7 +2093,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-tsa"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2119,7 +2119,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-types"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "base64",
  "chrono",
@@ -2132,7 +2132,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-verify"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 license = "BSD-3-Clause"
 repository = "https://github.com/prefix-dev/sigstore-rust"
@@ -92,15 +92,15 @@ futures = "0.3"
 directories = "6.0"
 
 # Internal crates (path + version for publishing)
-sigstore-types = { path = "crates/sigstore-types", version = "0.6.1" }
-sigstore-crypto = { path = "crates/sigstore-crypto", version = "0.6.1" }
-sigstore-merkle = { path = "crates/sigstore-merkle", version = "0.6.1" }
-sigstore-tsa = { path = "crates/sigstore-tsa", version = "0.6.1", default-features = false }
-sigstore-trust-root = { path = "crates/sigstore-trust-root", version = "0.6.1" }
-sigstore-bundle = { path = "crates/sigstore-bundle", version = "0.6.1", default-features = false }
-sigstore-rekor = { path = "crates/sigstore-rekor", version = "0.6.1", default-features = false }
-sigstore-fulcio = { path = "crates/sigstore-fulcio", version = "0.6.1", default-features = false }
-sigstore-oidc = { path = "crates/sigstore-oidc", version = "0.6.1", default-features = false }
-sigstore-cache = { path = "crates/sigstore-cache", version = "0.6.1" }
-sigstore-verify = { path = "crates/sigstore-verify", version = "0.6.1", default-features = false }
-sigstore-sign = { path = "crates/sigstore-sign", version = "0.6.1", default-features = false }
+sigstore-types = { path = "crates/sigstore-types", version = "0.6.2" }
+sigstore-crypto = { path = "crates/sigstore-crypto", version = "0.6.2" }
+sigstore-merkle = { path = "crates/sigstore-merkle", version = "0.6.2" }
+sigstore-tsa = { path = "crates/sigstore-tsa", version = "0.6.2", default-features = false }
+sigstore-trust-root = { path = "crates/sigstore-trust-root", version = "0.6.2" }
+sigstore-bundle = { path = "crates/sigstore-bundle", version = "0.6.2", default-features = false }
+sigstore-rekor = { path = "crates/sigstore-rekor", version = "0.6.2", default-features = false }
+sigstore-fulcio = { path = "crates/sigstore-fulcio", version = "0.6.2", default-features = false }
+sigstore-oidc = { path = "crates/sigstore-oidc", version = "0.6.2", default-features = false }
+sigstore-cache = { path = "crates/sigstore-cache", version = "0.6.2" }
+sigstore-verify = { path = "crates/sigstore-verify", version = "0.6.2", default-features = false }
+sigstore-sign = { path = "crates/sigstore-sign", version = "0.6.2", default-features = false }

--- a/crates/sigstore-bundle/CHANGELOG.md
+++ b/crates/sigstore-bundle/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-bundle-v0.6.1...sigstore-bundle-v0.6.2) - 2026-02-04
+
+### Other
+
+- add native-tls feature, bump reqwest ([#51](https://github.com/prefix-dev/sigstore-rust/pull/51))
+
 ## [0.6.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-bundle-v0.5.0...sigstore-bundle-v0.6.0) - 2025-12-08
 
 ### Added

--- a/crates/sigstore-fulcio/CHANGELOG.md
+++ b/crates/sigstore-fulcio/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-fulcio-v0.6.1...sigstore-fulcio-v0.6.2) - 2026-02-04
+
+### Other
+
+- add native-tls feature, bump reqwest ([#51](https://github.com/prefix-dev/sigstore-rust/pull/51))
+
 ## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-fulcio-v0.2.0...sigstore-fulcio-v0.3.0) - 2025-11-28
 
 ### Fixed

--- a/crates/sigstore-oidc/CHANGELOG.md
+++ b/crates/sigstore-oidc/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-oidc-v0.6.1...sigstore-oidc-v0.6.2) - 2026-02-04
+
+### Other
+
+- add native-tls feature, bump reqwest ([#51](https://github.com/prefix-dev/sigstore-rust/pull/51))
+- Update README ([#45](https://github.com/prefix-dev/sigstore-rust/pull/45))
+
 ## [0.6.1](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-oidc-v0.6.0...sigstore-oidc-v0.6.1) - 2026-01-26
 
 ### Added

--- a/crates/sigstore-rekor/CHANGELOG.md
+++ b/crates/sigstore-rekor/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-rekor-v0.6.1...sigstore-rekor-v0.6.2) - 2026-02-04
+
+### Other
+
+- add native-tls feature, bump reqwest ([#51](https://github.com/prefix-dev/sigstore-rust/pull/51))
+
 ## [0.5.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-rekor-v0.4.0...sigstore-rekor-v0.5.0) - 2025-12-01
 
 ### Added

--- a/crates/sigstore-sign/CHANGELOG.md
+++ b/crates/sigstore-sign/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-sign-v0.6.1...sigstore-sign-v0.6.2) - 2026-02-04
+
+### Other
+
+- add native-tls feature, bump reqwest ([#51](https://github.com/prefix-dev/sigstore-rust/pull/51))
+
 ## [0.6.1](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-sign-v0.6.0...sigstore-sign-v0.6.1) - 2026-01-26
 
 ### Added

--- a/crates/sigstore-tsa/CHANGELOG.md
+++ b/crates/sigstore-tsa/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-tsa-v0.6.1...sigstore-tsa-v0.6.2) - 2026-02-04
+
+### Other
+
+- add native-tls feature, bump reqwest ([#51](https://github.com/prefix-dev/sigstore-rust/pull/51))
+
 ## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-tsa-v0.2.0...sigstore-tsa-v0.3.0) - 2025-11-28
 
 ### Other

--- a/crates/sigstore-verify/CHANGELOG.md
+++ b/crates/sigstore-verify/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-verify-v0.6.1...sigstore-verify-v0.6.2) - 2026-02-04
+
+### Other
+
+- add native-tls feature, bump reqwest ([#51](https://github.com/prefix-dev/sigstore-rust/pull/51))
+
 ## [0.6.1](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-verify-v0.6.0...sigstore-verify-v0.6.1) - 2026-01-26
 
 ### Fixed


### PR DESCRIPTION



## 🤖 New release

* `sigstore-types`: 0.6.1 -> 0.6.2
* `sigstore-crypto`: 0.6.1 -> 0.6.2
* `sigstore-merkle`: 0.6.1 -> 0.6.2
* `sigstore-tsa`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `sigstore-trust-root`: 0.6.1 -> 0.6.2
* `sigstore-cache`: 0.6.1 -> 0.6.2
* `sigstore-rekor`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `sigstore-bundle`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `sigstore-oidc`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `sigstore-fulcio`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `sigstore-verify`: 0.6.1 -> 0.6.2 (✓ API compatible changes)
* `sigstore-sign`: 0.6.1 -> 0.6.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `sigstore-types`

<blockquote>

## [0.6.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-types-v0.5.0...sigstore-types-v0.6.0) - 2025-12-08

### Other

- improve types and add interop test workflow ([#9](https://github.com/wolfv/sigstore-rust/pull/9))
</blockquote>

## `sigstore-crypto`

<blockquote>

## [0.4.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-crypto-v0.3.0...sigstore-crypto-v0.4.0) - 2025-11-28

### Other

- introduce new artifact api
</blockquote>

## `sigstore-merkle`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-merkle-v0.2.0...sigstore-merkle-v0.3.0) - 2025-11-28

### Other

- more cleanup of functions
</blockquote>

## `sigstore-tsa`

<blockquote>

## [0.6.2](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-tsa-v0.6.1...sigstore-tsa-v0.6.2) - 2026-02-04

### Other

- add native-tls feature, bump reqwest ([#51](https://github.com/prefix-dev/sigstore-rust/pull/51))
</blockquote>

## `sigstore-trust-root`

<blockquote>

## [0.5.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-trust-root-v0.4.0...sigstore-trust-root-v0.5.0) - 2025-12-01

### Added

- Add SigningConfig support and V2 bundle fixes ([#6](https://github.com/wolfv/sigstore-rust/pull/6))
</blockquote>

## `sigstore-cache`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-cache-v0.2.0...sigstore-cache-v0.3.0) - 2025-11-28

### Fixed

- fix clippy warnings

### Other

- add simple separation for cache domains
- add sigstore-cache
</blockquote>

## `sigstore-rekor`

<blockquote>

## [0.6.2](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-rekor-v0.6.1...sigstore-rekor-v0.6.2) - 2026-02-04

### Other

- add native-tls feature, bump reqwest ([#51](https://github.com/prefix-dev/sigstore-rust/pull/51))
</blockquote>

## `sigstore-bundle`

<blockquote>

## [0.6.2](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-bundle-v0.6.1...sigstore-bundle-v0.6.2) - 2026-02-04

### Other

- add native-tls feature, bump reqwest ([#51](https://github.com/prefix-dev/sigstore-rust/pull/51))
</blockquote>

## `sigstore-oidc`

<blockquote>

## [0.6.2](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-oidc-v0.6.1...sigstore-oidc-v0.6.2) - 2026-02-04

### Other

- add native-tls feature, bump reqwest ([#51](https://github.com/prefix-dev/sigstore-rust/pull/51))
- Update README ([#45](https://github.com/prefix-dev/sigstore-rust/pull/45))
</blockquote>

## `sigstore-fulcio`

<blockquote>

## [0.6.2](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-fulcio-v0.6.1...sigstore-fulcio-v0.6.2) - 2026-02-04

### Other

- add native-tls feature, bump reqwest ([#51](https://github.com/prefix-dev/sigstore-rust/pull/51))
</blockquote>

## `sigstore-verify`

<blockquote>

## [0.6.2](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-verify-v0.6.1...sigstore-verify-v0.6.2) - 2026-02-04

### Other

- add native-tls feature, bump reqwest ([#51](https://github.com/prefix-dev/sigstore-rust/pull/51))
</blockquote>

## `sigstore-sign`

<blockquote>

## [0.6.2](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-sign-v0.6.1...sigstore-sign-v0.6.2) - 2026-02-04

### Other

- add native-tls feature, bump reqwest ([#51](https://github.com/prefix-dev/sigstore-rust/pull/51))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).