### PR TITLE
fix: honor timestamp verification policy

### DIFF
--- a/crates/sigstore-verify/src/verify.rs
+++ b/crates/sigstore-verify/src/verify.rs
@@ -248,6 +248,7 @@ impl Verifier {
             bundle,
             &signature,
             &self.trusted_root,
+            policy.verify_timestamp,
         )?;
 
         // (1): Verify that the signing certificate chains to the root of trust,

--- a/crates/sigstore-verify/src/verify_impl/helpers.rs
+++ b/crates/sigstore-verify/src/verify_impl/helpers.rs
@@ -194,16 +194,28 @@ pub fn determine_validation_time(
     bundle: &Bundle,
     signature: &SignatureBytes,
     trusted_root: &TrustedRoot,
+    verify_timestamp: bool,
 ) -> Result<i64> {
-    // Try TSA timestamp first (most authoritative)
-    if let Some(tsa_time) = extract_tsa_timestamp(bundle, signature.as_bytes(), trusted_root)? {
-        return Ok(tsa_time);
-    }
+    // Try TSA timestamp first (most authoritative), unless disabled by policy.
+    let timestamp_error = if verify_timestamp {
+        match extract_tsa_timestamp(bundle, signature.as_bytes(), trusted_root) {
+            Ok(Some(tsa_time)) => return Ok(tsa_time),
+            Ok(None) => None,
+            Err(err) => Some(err),
+        }
+    } else {
+        None
+    };
 
     // Try integrated time from V1 tlog entries with inclusion promises
     // Per sigstore-python: integrated_time only counts if accompanied by inclusion_promise
     if let Some(integrated_time) = extract_v1_integrated_time_with_promise(bundle) {
         return Ok(integrated_time);
+    }
+
+    // Preserve TSA verification errors when no Rekor v1 time can be used instead.
+    if let Some(err) = timestamp_error {
+        return Err(err);
     }
 
     // No verified timestamp found - fail verification
@@ -422,4 +434,106 @@ fn get_issuer_spki(
     Err(Error::Verification(
         "could not find issuer certificate for SCT verification".to_string(),
     ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sigstore_types::bundle::{
+        CertificateContent, Rfc3161Timestamp, TimestampVerificationData,
+        VerificationMaterialContent,
+    };
+    use sigstore_types::{
+        CanonicalizedBody, InclusionPromise, KindVersion, LogId, LogIndex, LogKeyId,
+        MessageSignature, SignatureContent, SignedTimestamp, TimestampToken, TransparencyLogEntry,
+        VerificationMaterial,
+    };
+
+    fn trusted_root() -> TrustedRoot {
+        TrustedRoot::from_json(
+            r#"{
+                "mediaType": "application/vnd.dev.sigstore.trustedroot+json;version=0.1",
+                "tlogs": [],
+                "certificateAuthorities": [],
+                "ctlogs": [],
+                "timestampAuthorities": []
+            }"#,
+        )
+        .unwrap()
+    }
+
+    fn bundle(tlog_entries: Vec<TransparencyLogEntry>) -> Bundle {
+        Bundle {
+            media_type: "application/vnd.dev.sigstore.bundle.v0.3+json".to_string(),
+            verification_material: VerificationMaterial {
+                content: VerificationMaterialContent::Certificate(CertificateContent {
+                    raw_bytes: DerCertificate::from_bytes(b"cert"),
+                }),
+                tlog_entries,
+                timestamp_verification_data: TimestampVerificationData {
+                    rfc3161_timestamps: vec![Rfc3161Timestamp {
+                        signed_timestamp: TimestampToken::from_bytes(b"not a timestamp"),
+                    }],
+                },
+            },
+            content: SignatureContent::MessageSignature(MessageSignature {
+                message_digest: None,
+                signature: SignatureBytes::from_bytes(b"sig"),
+            }),
+        }
+    }
+
+    fn v1_tlog_entry(integrated_time: i64) -> TransparencyLogEntry {
+        TransparencyLogEntry {
+            log_index: LogIndex::new(0),
+            log_id: LogId {
+                key_id: LogKeyId::from_bytes(b"test-key-id"),
+            },
+            kind_version: KindVersion {
+                kind: "hashedrekord".to_string(),
+                version: "0.0.1".to_string(),
+            },
+            integrated_time,
+            inclusion_promise: Some(InclusionPromise {
+                signed_entry_timestamp: SignedTimestamp::from_bytes(b"set"),
+            }),
+            inclusion_proof: None,
+            canonicalized_body: CanonicalizedBody::from_bytes(b"body"),
+        }
+    }
+
+    #[test]
+    fn determine_validation_time_uses_tlog_when_timestamp_verification_disabled() {
+        let bundle = bundle(vec![v1_tlog_entry(1234)]);
+        let signature = SignatureBytes::from_bytes(b"sig");
+
+        let validation_time =
+            determine_validation_time(&bundle, &signature, &trusted_root(), false).unwrap();
+
+        assert_eq!(validation_time, 1234);
+    }
+
+    #[test]
+    fn determine_validation_time_falls_back_to_tlog_when_tsa_fails() {
+        let bundle = bundle(vec![v1_tlog_entry(1234)]);
+        let signature = SignatureBytes::from_bytes(b"sig");
+
+        let validation_time =
+            determine_validation_time(&bundle, &signature, &trusted_root(), true).unwrap();
+
+        assert_eq!(validation_time, 1234);
+    }
+
+    #[test]
+    fn determine_validation_time_preserves_tsa_error_without_tlog_fallback() {
+        let bundle = bundle(vec![]);
+        let signature = SignatureBytes::from_bytes(b"sig");
+
+        let err = determine_validation_time(&bundle, &signature, &trusted_root(), true)
+            .expect_err("invalid timestamp should fail without a tlog fallback");
+
+        assert!(err
+            .to_string()
+            .contains("TSA timestamp verification failed"));
+    }
 }


### PR DESCRIPTION
## Summary

- honor `VerificationPolicy::skip_timestamp()` when choosing a verified validation time
- fall back to Rekor v1 integrated time when RFC3161 timestamp verification fails but a valid v1 tlog timestamp source exists
- keep timestamp-only failures reporting the underlying TSA verification error

## Why

`VerificationPolicy` exposes `skip_timestamp()`, but `Verifier::verify()` still always attempted RFC3161 timestamp verification while establishing the certificate validation time. That means callers could not opt out of TSA verification even when they had a valid Rekor v1 timestamp source available.

It also meant a bundle with both timestamp data and a usable Rekor v1 `integrated_time` could fail before the Rekor timestamp source was considered.

## Seen in the wild

This came up while switching [`mise`](https://github.com/jdx/mise) from `sigstore-verification` to this crate for GitHub artifact attestations. Two public GitHub release artifacts that triggered the issue path were:

- [`jdx/communique@v0.1.9`](https://github.com/jdx/communique/releases/tag/v0.1.9), installed by mise as `github:jdx/communique@0.1.9`
- [`endevco/aube@v1.0.0-beta.5`](https://github.com/endevco/aube/releases/tag/v1.0.0-beta.5), installed by mise through an npm-backed tool flow

Both hit this failure while verifying GitHub artifact attestations with `sigstore-rust`:

```text
Verification failed: Sigstore error: Verification error: TSA timestamp verification failed: Failed to verify timestamp signature: no certificate matches issuer and serial number
```

Those cases are useful because they show two separate needs:

1. Callers need policy control over whether RFC3161 timestamps participate in validation-time selection. Today, `skip_timestamp()` exists but is not honored by this path.
2. When a bundle has a usable Rekor v1 timestamp source, a TSA verification problem should not prevent trying that fallback.

For timestamp-only GitHub bundles with no Rekor v1 fallback, this PR intentionally still returns the TSA error. That keeps the failure actionable and avoids silently accepting a bundle without a verified time source.

## Behavior examples

### `skip_timestamp()` now skips TSA verification

A caller that wants to verify using Rekor time can disable timestamp verification:

```rust
let policy = VerificationPolicy::default().skip_timestamp();
verifier.verify(&bundle, &policy)?;
```

Before this change, `skip_timestamp()` set `verify_timestamp = false`, but the verifier still called RFC3161 verification while determining the validation time. Invalid or untrusted TSA data could fail verification before the Rekor v1 integrated time was used.

After this change, TSA verification is skipped for validation-time selection when `skip_timestamp()` is set. A v1 tlog entry with `integrated_time > 0` and an inclusion promise can provide the validation time.

### TSA failure can fall back to Rekor v1 time

For a v1 bundle that contains both:

- RFC3161 timestamp data that cannot be verified against the current trust root
- a Rekor v1 tlog entry with an inclusion promise and positive `integrated_time`

Before this change, verification returned the TSA error immediately, for example:

```text
TSA timestamp verification failed: no certificate matches issuer and serial number
```

After this change, the verifier records that TSA error, checks whether Rekor v1 can provide a verified time, and uses the Rekor integrated time when available.

### Timestamp-only bundles still fail on TSA errors

This does not mask timestamp failures for bundles that have no Rekor v1 fallback. If RFC3161 timestamp verification fails and there is no usable v1 tlog time, verification still returns the TSA verification error.

## Tests

- `cargo test -p sigstore-verify determine_validation_time --lib`
- `cargo fmt --check`
