### PR TITLE
fix(sigstore-types): handle missing optional fields in cosign v3 bundles

### DIFF
--- a/crates/sigstore-types/src/bundle.rs
+++ b/crates/sigstore-types/src/bundle.rs
@@ -232,7 +232,8 @@ pub struct X509Certificate {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct TransparencyLogEntry {
-    /// Log index
+    /// Log index. May be omitted by cosign v3 (defaults to 0 per proto3 semantics).
+    #[serde(default)]
     pub log_index: LogIndex,
     /// Log ID
     pub log_id: LogId,
@@ -282,15 +283,16 @@ pub struct InclusionPromise {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct InclusionProof {
-    /// Index of the entry in the log
+    /// Index of the entry in the log. May be omitted by cosign v3.
+    #[serde(default)]
     pub log_index: LogIndex,
     /// Root hash of the tree
     pub root_hash: Sha256Hash,
     /// Tree size at time of proof
     #[serde(with = "string_i64")]
     pub tree_size: i64,
-    /// Hashes in the inclusion proof path
-    #[serde(with = "sha256_hash_vec")]
+    /// Hashes in the inclusion proof path. May be empty for single-entry trees.
+    #[serde(default, with = "sha256_hash_vec")]
     pub hashes: Vec<Sha256Hash>,
     /// Checkpoint (signed tree head) - optional
     #[serde(default, skip_serializing_if = "CheckpointData::is_empty")]
@@ -411,5 +413,63 @@ mod tests {
     #[test]
     fn test_media_type_invalid() {
         assert!(MediaType::from_str("invalid").is_err());
+    }
+
+    #[test]
+    fn test_tlog_entry_missing_log_index() {
+        // cosign v3 omits logIndex from tlog entries
+        let json = r#"{
+            "logId": {"keyId": "dGVzdA=="},
+            "kindVersion": {"kind": "dsse", "version": "0.0.1"},
+            "integratedTime": "1700000000",
+            "canonicalizedBody": "e30="
+        }"#;
+        let entry: TransparencyLogEntry = serde_json::from_str(json).unwrap();
+        assert_eq!(entry.log_index.as_u64(), Some(0));
+    }
+
+    #[test]
+    fn test_inclusion_proof_missing_optional_fields() {
+        // cosign v3 omits logIndex and hashes from inclusion proofs
+        let json = r#"{
+            "rootHash": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+            "treeSize": "1",
+            "checkpoint": {"envelope": "test\n1\nAAA=\n\n— test AAAA\n"}
+        }"#;
+        let proof: InclusionProof = serde_json::from_str(json).unwrap();
+        assert_eq!(proof.log_index.as_u64(), Some(0));
+        assert!(proof.hashes.is_empty());
+    }
+
+    #[test]
+    fn test_parse_cosign_v3_bundle_with_missing_fields() {
+        // Full bundle as produced by cosign v3 with private Fulcio/Rekor,
+        // where logIndex, hashes, and subject name are omitted.
+        let json = include_str!("../test_data/cosign_v3_missing_fields.json");
+        let bundle = Bundle::from_json(json)
+            .expect("should parse cosign v3 bundle with missing optional fields");
+
+        // Verify tlog entry parsed with default logIndex
+        let entry = &bundle.verification_material.tlog_entries[0];
+        assert_eq!(entry.log_index.as_u64(), Some(0));
+
+        // Verify inclusion proof parsed without logIndex and hashes
+        let proof = entry.inclusion_proof.as_ref().unwrap();
+        assert_eq!(proof.log_index.as_u64(), Some(0));
+        assert!(proof.hashes.is_empty());
+
+        // Verify DSSE envelope with subject missing name
+        if let super::SignatureContent::DsseEnvelope(env) = &bundle.content {
+            let payload = env.decode_payload();
+            let statement: super::super::intoto::Statement =
+                serde_json::from_slice(&payload).expect("should parse in-toto statement");
+            assert_eq!(statement.subject[0].name, "");
+            assert_eq!(
+                statement.subject[0].digest.sha256,
+                Some("abc123".to_string())
+            );
+        } else {
+            panic!("expected DSSE envelope");
+        }
     }
 }

--- a/crates/sigstore-types/src/encoding.rs
+++ b/crates/sigstore-types/src/encoding.rs
@@ -410,7 +410,7 @@ impl std::fmt::Display for EntryUuid {
 /// Represents a log index in the transparency log. Per the protobuf spec,
 /// this is an int64. For JSON serialization, we serialize as an integer but
 /// accept both integers and strings for backwards compatibility.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub struct LogIndex(i64);
 
 impl LogIndex {

--- a/crates/sigstore-types/src/intoto.rs
+++ b/crates/sigstore-types/src/intoto.rs
@@ -33,7 +33,9 @@ pub struct Statement {
 /// its name and cryptographic digest(s).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct Subject {
-    /// Name of the artifact (e.g., file name, package name)
+    /// Name of the artifact (e.g., file name, package name).
+    /// Defaults to empty string when omitted (cosign v3 omits this for container signing).
+    #[serde(default)]
     pub name: String,
     /// Cryptographic digest(s) of the artifact
     pub digest: Digest,
@@ -123,5 +125,22 @@ mod tests {
         assert!(statement.matches_sha256("hash1"));
         assert!(statement.matches_sha256("hash2"));
         assert!(!statement.matches_sha256("hash3"));
+    }
+
+    #[test]
+    fn test_subject_missing_name() {
+        // cosign v3 omits "name" from in-toto statement subjects
+        let json = r#"{
+            "_type": "https://in-toto.io/Statement/v1",
+            "subject": [{"digest": {"sha256": "abc123"}}],
+            "predicateType": "https://sigstore.dev/cosign/sign/v1",
+            "predicate": {}
+        }"#;
+        let statement: Statement = serde_json::from_str(json).unwrap();
+        assert_eq!(statement.subject[0].name, "");
+        assert_eq!(
+            statement.subject[0].digest.sha256,
+            Some("abc123".to_string())
+        );
     }
 }

--- a/crates/sigstore-types/test_data/cosign_v3_missing_fields.json
+++ b/crates/sigstore-types/test_data/cosign_v3_missing_fields.json
@@ -1,0 +1,40 @@
+{
+  "mediaType": "application/vnd.dev.sigstore.bundle.v0.3+json",
+  "verificationMaterial": {
+    "certificate": {
+      "rawBytes": "dGVzdA=="
+    },
+    "tlogEntries": [
+      {
+        "logId": {
+          "keyId": "dGVzdA=="
+        },
+        "kindVersion": {
+          "kind": "dsse",
+          "version": "0.0.1"
+        },
+        "integratedTime": "1700000000",
+        "inclusionPromise": {
+          "signedEntryTimestamp": "dGVzdA=="
+        },
+        "inclusionProof": {
+          "rootHash": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+          "treeSize": "1",
+          "checkpoint": {
+            "envelope": "test - 123\n1\nAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=\n\n\u2014 test AAAA\n"
+          }
+        },
+        "canonicalizedBody": "e30="
+      }
+    ]
+  },
+  "dsseEnvelope": {
+    "payload": "eyJfdHlwZSI6Imh0dHBzOi8vaW4tdG90by5pby9TdGF0ZW1lbnQvdjEiLCJzdWJqZWN0IjpbeyJkaWdlc3QiOnsic2hhMjU2IjoiYWJjMTIzIn19XSwicHJlZGljYXRlVHlwZSI6Imh0dHBzOi8vc2lnc3RvcmUuZGV2L2Nvc2lnbi9zaWduL3YxIiwicHJlZGljYXRlIjp7fX0=",
+    "payloadType": "application/vnd.in-toto+json",
+    "signatures": [
+      {
+        "sig": "dGVzdA=="
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

cosign v3.0.6 produces Sigstore v0.3 bundles that omit several fields which are optional per proto3 semantics but required by serde deserialization in sigstore-types. `Bundle::from_json()` fails with "missing field" errors.

## Changes

| File | Field | Change | Reason |
|------|-------|--------|--------|
| `intoto.rs` | `Subject.name` | `#[serde(default)]` | cosign v3 omits "name" from in-toto subjects for container signing |
| `bundle.rs` | `TransparencyLogEntry.log_index` | `#[serde(default)]` | cosign v3 omits logIndex from tlog entries |
| `bundle.rs` | `InclusionProof.log_index` | `#[serde(default)]` | cosign v3 omits logIndex from inclusion proofs |
| `bundle.rs` | `InclusionProof.hashes` | `#[serde(default)]` | cosign v3 omits hashes when proof path is empty |
| `encoding.rs` | `LogIndex` | `Default` derive | Required for `#[serde(default)]` |

All fields default to zero/empty per proto3 convention.

## Reproduction

```bash
# Sign with cosign v3.0.6 against private Fulcio + Rekor
cosign sign \
  --use-signing-config=false \
  --fulcio-url http://localhost:PORT \
  --rekor-url http://localhost:PORT \
  --identity-token <token> \
  --allow-insecure-registry \
  <image>
```

Then parse the resulting bundle:
```rust
let bundle = Bundle::from_json(&bundle_str)?;
// Error: "missing field `logIndex` at line 1 column ..."
```

## Tests

- `test_subject_missing_name` — parse in-toto statement without subject name
- `test_tlog_entry_missing_log_index` — parse tlog entry without logIndex
- `test_inclusion_proof_missing_optional_fields` — parse proof without logIndex/hashes
- `test_parse_cosign_v3_bundle_with_missing_fields` — full bundle fixture with all missing fields
- All 27 sigstore-types tests pass

## Test plan
- [x] Unit tests for each missing field
- [x] Integration fixture test with a complete cosign v3 bundle
- [x] All existing tests pass (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)