### PR TITLE
chore: release v0.6.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1999,7 +1999,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-bundle"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "base64",
  "hex",
@@ -2015,7 +2015,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-cache"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "chrono",
  "directories",
@@ -2027,7 +2027,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-conformance"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "base64",
  "hex",
@@ -2048,7 +2048,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-crypto"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2069,7 +2069,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-fulcio"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "base64",
  "hex",
@@ -2087,7 +2087,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-merkle"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "base64",
  "hex",
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-oidc"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "ambient-id",
  "base64",
@@ -2119,7 +2119,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-rekor"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "base64",
  "hex",
@@ -2137,7 +2137,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-sign"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "base64",
  "chrono",
@@ -2159,7 +2159,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-trust-root"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "base64",
  "chrono",
@@ -2182,7 +2182,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-tsa"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2208,7 +2208,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-types"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "base64",
  "chrono",
@@ -2221,7 +2221,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-verify"
-version = "0.6.5"
+version = "0.6.6"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.5"
+version = "0.6.6"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/prefix-dev/sigstore-rust"
@@ -95,15 +95,15 @@ directories = "6.0"
 open = "5.3"
 
 # Internal crates (path + version for publishing)
-sigstore-types = { path = "crates/sigstore-types", version = "0.6.5" }
-sigstore-crypto = { path = "crates/sigstore-crypto", version = "0.6.5" }
-sigstore-merkle = { path = "crates/sigstore-merkle", version = "0.6.5" }
-sigstore-tsa = { path = "crates/sigstore-tsa", version = "0.6.5", default-features = false }
-sigstore-trust-root = { path = "crates/sigstore-trust-root", version = "0.6.5", default-features = false }
-sigstore-bundle = { path = "crates/sigstore-bundle", version = "0.6.5", default-features = false }
-sigstore-rekor = { path = "crates/sigstore-rekor", version = "0.6.5", default-features = false }
-sigstore-fulcio = { path = "crates/sigstore-fulcio", version = "0.6.5", default-features = false }
-sigstore-oidc = { path = "crates/sigstore-oidc", version = "0.6.5", default-features = false }
-sigstore-cache = { path = "crates/sigstore-cache", version = "0.6.5" }
-sigstore-verify = { path = "crates/sigstore-verify", version = "0.6.5", default-features = false }
-sigstore-sign = { path = "crates/sigstore-sign", version = "0.6.5", default-features = false }
+sigstore-types = { path = "crates/sigstore-types", version = "0.6.6" }
+sigstore-crypto = { path = "crates/sigstore-crypto", version = "0.6.6" }
+sigstore-merkle = { path = "crates/sigstore-merkle", version = "0.6.6" }
+sigstore-tsa = { path = "crates/sigstore-tsa", version = "0.6.6", default-features = false }
+sigstore-trust-root = { path = "crates/sigstore-trust-root", version = "0.6.6", default-features = false }
+sigstore-bundle = { path = "crates/sigstore-bundle", version = "0.6.6", default-features = false }
+sigstore-rekor = { path = "crates/sigstore-rekor", version = "0.6.6", default-features = false }
+sigstore-fulcio = { path = "crates/sigstore-fulcio", version = "0.6.6", default-features = false }
+sigstore-oidc = { path = "crates/sigstore-oidc", version = "0.6.6", default-features = false }
+sigstore-cache = { path = "crates/sigstore-cache", version = "0.6.6" }
+sigstore-verify = { path = "crates/sigstore-verify", version = "0.6.6", default-features = false }
+sigstore-sign = { path = "crates/sigstore-sign", version = "0.6.6", default-features = false }

--- a/crates/sigstore-tsa/CHANGELOG.md
+++ b/crates/sigstore-tsa/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.6](https://github.com/sigstore/sigstore-rust/compare/sigstore-tsa-v0.6.5...sigstore-tsa-v0.6.6) - 2026-04-29
+
+### Fixed
+
+- *(sigstore-tsa)* honor SignerInfo digest algorithm in CMS verification ([#83](https://github.com/sigstore/sigstore-rust/pull/83))
+
 ## [0.6.4](https://github.com/sigstore/sigstore-rust/compare/sigstore-tsa-v0.6.3...sigstore-tsa-v0.6.4) - 2026-03-06
 
 ### Fixed

--- a/crates/sigstore-types/CHANGELOG.md
+++ b/crates/sigstore-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.6](https://github.com/sigstore/sigstore-rust/compare/sigstore-types-v0.6.5...sigstore-types-v0.6.6) - 2026-04-29
+
+### Fixed
+
+- *(sigstore-types)* handle missing optional fields in cosign v3 bundles ([#82](https://github.com/sigstore/sigstore-rust/pull/82))
+
 ## [0.6.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-types-v0.5.0...sigstore-types-v0.6.0) - 2025-12-08
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `sigstore-types`: 0.6.5 -> 0.6.6 (✓ API compatible changes)
* `sigstore-crypto`: 0.6.5 -> 0.6.6
* `sigstore-merkle`: 0.6.5 -> 0.6.6
* `sigstore-tsa`: 0.6.5 -> 0.6.6 (✓ API compatible changes)
* `sigstore-trust-root`: 0.6.5 -> 0.6.6
* `sigstore-cache`: 0.6.5 -> 0.6.6
* `sigstore-rekor`: 0.6.5 -> 0.6.6
* `sigstore-bundle`: 0.6.5 -> 0.6.6
* `sigstore-oidc`: 0.6.5 -> 0.6.6
* `sigstore-fulcio`: 0.6.5 -> 0.6.6
* `sigstore-verify`: 0.6.5 -> 0.6.6
* `sigstore-sign`: 0.6.5 -> 0.6.6

<details><summary><i><b>Changelog</b></i></summary><p>

## `sigstore-types`

<blockquote>

## [0.6.6](https://github.com/sigstore/sigstore-rust/compare/sigstore-types-v0.6.5...sigstore-types-v0.6.6) - 2026-04-29

### Fixed

- *(sigstore-types)* handle missing optional fields in cosign v3 bundles ([#82](https://github.com/sigstore/sigstore-rust/pull/82))
</blockquote>

## `sigstore-crypto`

<blockquote>

## [0.6.4](https://github.com/sigstore/sigstore-rust/compare/sigstore-crypto-v0.6.3...sigstore-crypto-v0.6.4) - 2026-03-06

### Fixed

- be more strict about unknown key types and verification ([#70](https://github.com/sigstore/sigstore-rust/pull/70))
</blockquote>

## `sigstore-merkle`

<blockquote>

## [0.6.5](https://github.com/sigstore/sigstore-rust/compare/sigstore-merkle-v0.6.4...sigstore-merkle-v0.6.5) - 2026-04-19

### Other

- Fix inclusion proof border length
</blockquote>

## `sigstore-tsa`

<blockquote>

## [0.6.6](https://github.com/sigstore/sigstore-rust/compare/sigstore-tsa-v0.6.5...sigstore-tsa-v0.6.6) - 2026-04-29

### Fixed

- *(sigstore-tsa)* honor SignerInfo digest algorithm in CMS verification ([#83](https://github.com/sigstore/sigstore-rust/pull/83))
</blockquote>

## `sigstore-trust-root`

<blockquote>

## [0.6.5](https://github.com/sigstore/sigstore-rust/compare/sigstore-trust-root-v0.6.4...sigstore-trust-root-v0.6.5) - 2026-04-19

### Other

- API for fetching / using the trust root ([#69](https://github.com/sigstore/sigstore-rust/pull/69))
</blockquote>

## `sigstore-cache`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-cache-v0.2.0...sigstore-cache-v0.3.0) - 2025-11-28

### Fixed

- fix clippy warnings

### Other

- add simple separation for cache domains
- add sigstore-cache
</blockquote>

## `sigstore-rekor`

<blockquote>

## [0.6.2](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-rekor-v0.6.1...sigstore-rekor-v0.6.2) - 2026-02-04

### Other

- add native-tls feature, bump reqwest ([#51](https://github.com/prefix-dev/sigstore-rust/pull/51))
</blockquote>

## `sigstore-bundle`

<blockquote>

## [0.6.5](https://github.com/sigstore/sigstore-rust/compare/sigstore-bundle-v0.6.4...sigstore-bundle-v0.6.5) - 2026-04-19

### Other

- Allow timestamp-backed bundles without tlog entries ([#80](https://github.com/sigstore/sigstore-rust/pull/80))
</blockquote>

## `sigstore-oidc`

<blockquote>

## [0.6.5](https://github.com/sigstore/sigstore-rust/compare/sigstore-oidc-v0.6.4...sigstore-oidc-v0.6.5) - 2026-04-19

### Other

- Drain request before disconnection ([#78](https://github.com/sigstore/sigstore-rust/pull/78))
</blockquote>

## `sigstore-fulcio`

<blockquote>

## [0.6.2](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-fulcio-v0.6.1...sigstore-fulcio-v0.6.2) - 2026-02-04

### Other

- add native-tls feature, bump reqwest ([#51](https://github.com/prefix-dev/sigstore-rust/pull/51))
</blockquote>

## `sigstore-verify`

<blockquote>

## [0.6.5](https://github.com/sigstore/sigstore-rust/compare/sigstore-verify-v0.6.4...sigstore-verify-v0.6.5) - 2026-04-19

### Other

- API for fetching / using the trust root ([#69](https://github.com/sigstore/sigstore-rust/pull/69))
</blockquote>

## `sigstore-sign`

<blockquote>

## [0.6.5](https://github.com/sigstore/sigstore-rust/compare/sigstore-sign-v0.6.4...sigstore-sign-v0.6.5) - 2026-04-19

### Other

- API for fetching / using the trust root ([#69](https://github.com/sigstore/sigstore-rust/pull/69))
- Avoid hashing the payload twice
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).