### PR TITLE
chore: release v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1997,7 +1997,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-bundle"
-version = "0.6.6"
+version = "0.7.0"
 dependencies = [
  "base64",
  "hex",
@@ -2013,7 +2013,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-cache"
-version = "0.6.6"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "directories",
@@ -2025,7 +2025,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-conformance"
-version = "0.6.6"
+version = "0.7.0"
 dependencies = [
  "base64",
  "hex",
@@ -2046,7 +2046,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-crypto"
-version = "0.6.6"
+version = "0.7.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-fulcio"
-version = "0.6.6"
+version = "0.7.0"
 dependencies = [
  "base64",
  "hex",
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-merkle"
-version = "0.6.6"
+version = "0.7.0"
 dependencies = [
  "base64",
  "hex",
@@ -2099,7 +2099,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-oidc"
-version = "0.6.6"
+version = "0.7.0"
 dependencies = [
  "ambient-id",
  "base64",
@@ -2117,7 +2117,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-rekor"
-version = "0.6.6"
+version = "0.7.0"
 dependencies = [
  "base64",
  "hex",
@@ -2135,7 +2135,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-sign"
-version = "0.6.6"
+version = "0.7.0"
 dependencies = [
  "base64",
  "chrono",
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-trust-root"
-version = "0.6.6"
+version = "0.7.0"
 dependencies = [
  "base64",
  "chrono",
@@ -2181,7 +2181,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-tsa"
-version = "0.6.6"
+version = "0.7.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2207,7 +2207,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-types"
-version = "0.6.6"
+version = "0.7.0"
 dependencies = [
  "base64",
  "chrono",
@@ -2220,7 +2220,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-verify"
-version = "0.6.6"
+version = "0.7.0"
 dependencies = [
  "base64",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.6"
+version = "0.7.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/prefix-dev/sigstore-rust"
@@ -95,15 +95,15 @@ directories = "6.0"
 open = "5.3"
 
 # Internal crates (path + version for publishing)
-sigstore-types = { path = "crates/sigstore-types", version = "0.6.6" }
-sigstore-crypto = { path = "crates/sigstore-crypto", version = "0.6.6" }
-sigstore-merkle = { path = "crates/sigstore-merkle", version = "0.6.6" }
-sigstore-tsa = { path = "crates/sigstore-tsa", version = "0.6.6", default-features = false }
-sigstore-trust-root = { path = "crates/sigstore-trust-root", version = "0.6.6", default-features = false }
-sigstore-bundle = { path = "crates/sigstore-bundle", version = "0.6.6", default-features = false }
-sigstore-rekor = { path = "crates/sigstore-rekor", version = "0.6.6", default-features = false }
-sigstore-fulcio = { path = "crates/sigstore-fulcio", version = "0.6.6", default-features = false }
-sigstore-oidc = { path = "crates/sigstore-oidc", version = "0.6.6", default-features = false }
-sigstore-cache = { path = "crates/sigstore-cache", version = "0.6.6" }
-sigstore-verify = { path = "crates/sigstore-verify", version = "0.6.6", default-features = false }
-sigstore-sign = { path = "crates/sigstore-sign", version = "0.6.6", default-features = false }
+sigstore-types = { path = "crates/sigstore-types", version = "0.7.0" }
+sigstore-crypto = { path = "crates/sigstore-crypto", version = "0.7.0" }
+sigstore-merkle = { path = "crates/sigstore-merkle", version = "0.7.0" }
+sigstore-tsa = { path = "crates/sigstore-tsa", version = "0.7.0", default-features = false }
+sigstore-trust-root = { path = "crates/sigstore-trust-root", version = "0.7.0", default-features = false }
+sigstore-bundle = { path = "crates/sigstore-bundle", version = "0.7.0", default-features = false }
+sigstore-rekor = { path = "crates/sigstore-rekor", version = "0.7.0", default-features = false }
+sigstore-fulcio = { path = "crates/sigstore-fulcio", version = "0.7.0", default-features = false }
+sigstore-oidc = { path = "crates/sigstore-oidc", version = "0.7.0", default-features = false }
+sigstore-cache = { path = "crates/sigstore-cache", version = "0.7.0" }
+sigstore-verify = { path = "crates/sigstore-verify", version = "0.7.0", default-features = false }
+sigstore-sign = { path = "crates/sigstore-sign", version = "0.7.0", default-features = false }

--- a/crates/sigstore-crypto/CHANGELOG.md
+++ b/crates/sigstore-crypto/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-crypto-v0.6.6...sigstore-crypto-v0.7.0) - 2026-05-13
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.6.4](https://github.com/sigstore/sigstore-rust/compare/sigstore-crypto-v0.6.3...sigstore-crypto-v0.6.4) - 2026-03-06
 
 ### Fixed

--- a/crates/sigstore-oidc/CHANGELOG.md
+++ b/crates/sigstore-oidc/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-oidc-v0.6.6...sigstore-oidc-v0.7.0) - 2026-05-13
+
+### Added
+
+- trust root update and dependency update ([#85](https://github.com/sigstore/sigstore-rust/pull/85))
+
 ## [0.6.5](https://github.com/sigstore/sigstore-rust/compare/sigstore-oidc-v0.6.4...sigstore-oidc-v0.6.5) - 2026-04-19
 
 ### Other

--- a/crates/sigstore-trust-root/CHANGELOG.md
+++ b/crates/sigstore-trust-root/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-trust-root-v0.6.6...sigstore-trust-root-v0.7.0) - 2026-05-13
+
+### Added
+
+- trust root update and dependency update ([#85](https://github.com/sigstore/sigstore-rust/pull/85))
+
+### Other
+
+- add github TUF root ([#88](https://github.com/sigstore/sigstore-rust/pull/88))
+
 ## [0.6.5](https://github.com/sigstore/sigstore-rust/compare/sigstore-trust-root-v0.6.4...sigstore-trust-root-v0.6.5) - 2026-04-19
 
 ### Other

--- a/crates/sigstore-tsa/CHANGELOG.md
+++ b/crates/sigstore-tsa/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-tsa-v0.6.6...sigstore-tsa-v0.7.0) - 2026-05-13
+
+### Added
+
+- trust root update and dependency update ([#85](https://github.com/sigstore/sigstore-rust/pull/85))
+
 ## [0.6.6](https://github.com/sigstore/sigstore-rust/compare/sigstore-tsa-v0.6.5...sigstore-tsa-v0.6.6) - 2026-04-29
 
 ### Fixed

--- a/crates/sigstore-verify/CHANGELOG.md
+++ b/crates/sigstore-verify/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-verify-v0.6.6...sigstore-verify-v0.7.0) - 2026-05-13
+
+### Added
+
+- support for GitHub's artifact attestation Sigstore instance ([#88](https://github.com/sigstore/sigstore-rust/pull/88))
+- `VerificationPolicy::skip_sct()` builder method to skip Signed Certificate Timestamp verification (needed for trust domains whose certificates do not carry public Sigstore CT SCTs)
+
+### Changed
+
+- **BREAKING**: `VerificationPolicy` gained a new public field `verify_sct: bool` (defaults to `true`). Code that constructs `VerificationPolicy` via struct literal must add this field; users of `Default::default()` and the builder methods are unaffected.
+- **BREAKING**: SCT verification is now controlled independently by `verify_sct` rather than implicitly gated on `verify_certificate`. `skip_certificate_chain()` continues to disable both.
+
 ## [0.6.5](https://github.com/sigstore/sigstore-rust/compare/sigstore-verify-v0.6.4...sigstore-verify-v0.6.5) - 2026-04-19
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `sigstore-types`: 0.6.6 -> 0.6.7
* `sigstore-crypto`: 0.6.6 -> 0.6.7 (✓ API compatible changes)
* `sigstore-merkle`: 0.6.6 -> 0.6.7
* `sigstore-tsa`: 0.6.6 -> 0.6.7 (✓ API compatible changes)
* `sigstore-trust-root`: 0.6.6 -> 0.6.7 (✓ API compatible changes)
* `sigstore-cache`: 0.6.6 -> 0.6.7
* `sigstore-rekor`: 0.6.6 -> 0.6.7
* `sigstore-bundle`: 0.6.6 -> 0.6.7
* `sigstore-oidc`: 0.6.6 -> 0.6.7 (✓ API compatible changes)
* `sigstore-fulcio`: 0.6.6 -> 0.6.7
* `sigstore-verify`: 0.6.6 -> 0.6.7 (✓ API compatible changes)
* `sigstore-sign`: 0.6.6 -> 0.6.7

<details><summary><i><b>Changelog</b></i></summary><p>

## `sigstore-types`

<blockquote>

## [0.6.6](https://github.com/sigstore/sigstore-rust/compare/sigstore-types-v0.6.5...sigstore-types-v0.6.6) - 2026-04-29

### Fixed

- *(sigstore-types)* handle missing optional fields in cosign v3 bundles ([#82](https://github.com/sigstore/sigstore-rust/pull/82))
</blockquote>

## `sigstore-crypto`

<blockquote>

## [0.6.7](https://github.com/sigstore/sigstore-rust/compare/sigstore-crypto-v0.6.6...sigstore-crypto-v0.6.7) - 2026-05-13

### Other

- update Cargo.toml dependencies
</blockquote>

## `sigstore-merkle`

<blockquote>

## [0.6.5](https://github.com/sigstore/sigstore-rust/compare/sigstore-merkle-v0.6.4...sigstore-merkle-v0.6.5) - 2026-04-19

### Other

- Fix inclusion proof border length
</blockquote>

## `sigstore-tsa`

<blockquote>

## [0.6.7](https://github.com/sigstore/sigstore-rust/compare/sigstore-tsa-v0.6.6...sigstore-tsa-v0.6.7) - 2026-05-13

### Added

- trust root update and dependency update ([#85](https://github.com/sigstore/sigstore-rust/pull/85))
</blockquote>

## `sigstore-trust-root`

<blockquote>

## [0.6.7](https://github.com/sigstore/sigstore-rust/compare/sigstore-trust-root-v0.6.6...sigstore-trust-root-v0.6.7) - 2026-05-13

### Added

- trust root update and dependency update ([#85](https://github.com/sigstore/sigstore-rust/pull/85))

### Other

- add github TUF root ([#88](https://github.com/sigstore/sigstore-rust/pull/88))
</blockquote>

## `sigstore-cache`

<blockquote>

## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-cache-v0.2.0...sigstore-cache-v0.3.0) - 2025-11-28

### Fixed

- fix clippy warnings

### Other

- add simple separation for cache domains
- add sigstore-cache
</blockquote>

## `sigstore-rekor`

<blockquote>

## [0.6.2](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-rekor-v0.6.1...sigstore-rekor-v0.6.2) - 2026-02-04

### Other

- add native-tls feature, bump reqwest ([#51](https://github.com/prefix-dev/sigstore-rust/pull/51))
</blockquote>

## `sigstore-bundle`

<blockquote>

## [0.6.5](https://github.com/sigstore/sigstore-rust/compare/sigstore-bundle-v0.6.4...sigstore-bundle-v0.6.5) - 2026-04-19

### Other

- Allow timestamp-backed bundles without tlog entries ([#80](https://github.com/sigstore/sigstore-rust/pull/80))
</blockquote>

## `sigstore-oidc`

<blockquote>

## [0.6.7](https://github.com/sigstore/sigstore-rust/compare/sigstore-oidc-v0.6.6...sigstore-oidc-v0.6.7) - 2026-05-13

### Added

- trust root update and dependency update ([#85](https://github.com/sigstore/sigstore-rust/pull/85))
</blockquote>

## `sigstore-fulcio`

<blockquote>

## [0.6.2](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-fulcio-v0.6.1...sigstore-fulcio-v0.6.2) - 2026-02-04

### Other

- add native-tls feature, bump reqwest ([#51](https://github.com/prefix-dev/sigstore-rust/pull/51))
</blockquote>

## `sigstore-verify`

<blockquote>

## [0.6.7](https://github.com/sigstore/sigstore-rust/compare/sigstore-verify-v0.6.6...sigstore-verify-v0.6.7) - 2026-05-13

### Other

- add github TUF root ([#88](https://github.com/sigstore/sigstore-rust/pull/88))
</blockquote>

## `sigstore-sign`

<blockquote>

## [0.6.5](https://github.com/sigstore/sigstore-rust/compare/sigstore-sign-v0.6.4...sigstore-sign-v0.6.5) - 2026-04-19

### Other

- API for fetching / using the trust root ([#69](https://github.com/sigstore/sigstore-rust/pull/69))
- Avoid hashing the payload twice
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).