### PR TITLE
Replace direct chrono usage with jiff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -210,10 +210,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -1008,6 +1006,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jiff"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+dependencies = [
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
+
+[[package]]
 name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1348,6 +1387,21 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2015,8 +2069,8 @@ dependencies = [
 name = "sigstore-cache"
 version = "0.7.0"
 dependencies = [
- "chrono",
  "directories",
+ "jiff",
  "serde",
  "serde_json",
  "thiserror",
@@ -2138,8 +2192,8 @@ name = "sigstore-sign"
 version = "0.7.0"
 dependencies = [
  "base64",
- "chrono",
  "hex",
+ "jiff",
  "serde",
  "serde_json",
  "sigstore-bundle",
@@ -2160,10 +2214,10 @@ name = "sigstore-trust-root"
 version = "0.7.0"
 dependencies = [
  "base64",
- "chrono",
  "directories",
  "futures",
  "hex",
+ "jiff",
  "reqwest 0.12.28",
  "rustls-pki-types",
  "serde",
@@ -2185,12 +2239,12 @@ version = "0.7.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
- "chrono",
  "cmpv2",
  "cms",
  "const-oid",
  "der",
  "hex",
+ "jiff",
  "rand",
  "reqwest 0.13.3",
  "rustls-pki-types",
@@ -2210,7 +2264,6 @@ name = "sigstore-types"
 version = "0.7.0"
 dependencies = [
  "base64",
- "chrono",
  "hex",
  "pem",
  "serde",
@@ -2223,10 +2276,10 @@ name = "sigstore-verify"
 version = "0.7.0"
 dependencies = [
  "base64",
- "chrono",
  "cms",
  "const-oid",
  "hex",
+ "jiff",
  "pem",
  "regex",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ url = "2.5"
 tokio = { version = "1.47", features = ["full"] }
 
 # Time
-chrono = { version = "0.4", features = ["serde"] }
+jiff = { version = "0.2", features = ["serde"] }
 
 # Testing
 hex = "0.4"

--- a/crates/sigstore-cache/Cargo.toml
+++ b/crates/sigstore-cache/Cargo.toml
@@ -22,7 +22,7 @@ tokio = { workspace = true, features = ["fs", "sync", "time"] }
 directories.workspace = true
 
 # Time
-chrono.workspace = true
+jiff.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/sigstore-cache/src/filesystem.rs
+++ b/crates/sigstore-cache/src/filesystem.rs
@@ -3,7 +3,7 @@
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-use chrono::{DateTime, Utc};
+use jiff::{SignedDuration, Timestamp};
 use serde::{Deserialize, Serialize};
 use tokio::fs;
 
@@ -42,9 +42,9 @@ fn url_to_dirname(url: &str) -> String {
 #[derive(Debug, Serialize, Deserialize)]
 struct CacheMetadata {
     /// When the cache entry was created
-    created_at: DateTime<Utc>,
+    created_at: Timestamp,
     /// When the cache entry expires
-    expires_at: DateTime<Utc>,
+    expires_at: Timestamp,
 }
 
 /// File system based cache
@@ -180,7 +180,7 @@ impl FileSystemCache {
         match fs::read_to_string(&meta_path).await {
             Ok(content) => {
                 let metadata: CacheMetadata = serde_json::from_str(&content)?;
-                if Utc::now() < metadata.expires_at {
+                if Timestamp::now() < metadata.expires_at {
                     Ok(Some(metadata))
                 } else {
                     // Expired - clean up
@@ -217,11 +217,12 @@ impl CacheAdapter for FileSystemCache {
         Box::pin(async move {
             self.ensure_dir().await?;
 
-            let now = Utc::now();
+            let now = Timestamp::now();
+            let ttl = SignedDuration::try_from(ttl)
+                .unwrap_or_else(|_| SignedDuration::from_secs(24 * 60 * 60));
             let metadata = CacheMetadata {
                 created_at: now,
-                expires_at: now
-                    + chrono::Duration::from_std(ttl).unwrap_or(chrono::Duration::days(1)),
+                expires_at: now + ttl,
             };
 
             // Write metadata first (atomic-ish - if this fails, cache entry is invalid)

--- a/crates/sigstore-sign/Cargo.toml
+++ b/crates/sigstore-sign/Cargo.toml
@@ -23,7 +23,7 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true }
-chrono = { workspace = true }
+jiff = { workspace = true }
 serde = { workspace = true }
 hex = { workspace = true }
 

--- a/crates/sigstore-sign/examples/sign_attestation.rs
+++ b/crates/sigstore-sign/examples/sign_attestation.rs
@@ -216,8 +216,8 @@ async fn main() {
         if ts == 0 {
             println!("  Integrated Time: (uses RFC3161 timestamps)");
         } else {
-            use chrono::{DateTime, Utc};
-            if let Some(dt) = DateTime::<Utc>::from_timestamp(ts, 0) {
+            use jiff::Timestamp;
+            if let Ok(dt) = Timestamp::from_second(ts) {
                 println!("  Integrated Time: {}", dt);
             }
         }

--- a/crates/sigstore-sign/examples/sign_blob.rs
+++ b/crates/sigstore-sign/examples/sign_blob.rs
@@ -200,8 +200,8 @@ async fn main() {
         if ts == 0 && entry.kind_version.version == "0.0.2" {
             println!("  Integrated Time: (V2 uses RFC3161 timestamps)");
         } else {
-            use chrono::{DateTime, Utc};
-            if let Some(dt) = DateTime::<Utc>::from_timestamp(ts, 0) {
+            use jiff::Timestamp;
+            if let Ok(dt) = Timestamp::from_second(ts) {
                 println!("  Integrated Time: {}", dt);
             }
         }

--- a/crates/sigstore-trust-root/Cargo.toml
+++ b/crates/sigstore-trust-root/Cargo.toml
@@ -37,7 +37,7 @@ x509-cert = { workspace = true }
 rustls-pki-types = { workspace = true }
 
 # Time handling
-chrono = { workspace = true }
+jiff = { workspace = true }
 
 # Utilities
 hex = { workspace = true }

--- a/crates/sigstore-trust-root/src/signing_config.rs
+++ b/crates/sigstore-trust-root/src/signing_config.rs
@@ -33,7 +33,7 @@
 //! let config = SigningConfig::from_json(SIGSTORE_PRODUCTION_SIGNING_CONFIG).unwrap();
 //! ```
 
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 use serde::{Deserialize, Serialize};
 
 use crate::{Error, Result};
@@ -63,16 +63,16 @@ pub const SIGNING_CONFIG_MEDIA_TYPE: &str = "application/vnd.dev.sigstore.signin
 #[serde(rename_all = "camelCase")]
 pub struct ServiceValidityPeriod {
     /// Start time of validity
-    pub start: DateTime<Utc>,
+    pub start: Timestamp,
     /// End time of validity (optional, None means still valid)
     #[serde(default)]
-    pub end: Option<DateTime<Utc>>,
+    pub end: Option<Timestamp>,
 }
 
 impl ServiceValidityPeriod {
     /// Check if this period is currently valid
     pub fn is_valid(&self) -> bool {
-        let now = Utc::now();
+        let now = Timestamp::now();
         if now < self.start {
             return false;
         }
@@ -324,22 +324,14 @@ mod tests {
     #[test]
     fn test_service_validity() {
         let valid_period = ServiceValidityPeriod {
-            start: DateTime::parse_from_rfc3339("2020-01-01T00:00:00Z")
-                .unwrap()
-                .into(),
+            start: "2020-01-01T00:00:00Z".parse().unwrap(),
             end: None,
         };
         assert!(valid_period.is_valid());
 
         let expired_period = ServiceValidityPeriod {
-            start: DateTime::parse_from_rfc3339("2020-01-01T00:00:00Z")
-                .unwrap()
-                .into(),
-            end: Some(
-                DateTime::parse_from_rfc3339("2021-01-01T00:00:00Z")
-                    .unwrap()
-                    .into(),
-            ),
+            start: "2020-01-01T00:00:00Z".parse().unwrap(),
+            end: Some("2021-01-01T00:00:00Z".parse().unwrap()),
         };
         assert!(!expired_period.is_valid());
     }

--- a/crates/sigstore-trust-root/src/trusted_root.rs
+++ b/crates/sigstore-trust-root/src/trusted_root.rs
@@ -1,7 +1,7 @@
 //! Trusted root types and parsing
 
 use crate::{Error, Result};
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 use rustls_pki_types::CertificateDer;
 use serde::{Deserialize, Serialize};
 use sigstore_types::{DerCertificate, DerPublicKey, HashAlgorithm, KeyHint, LogId, LogKeyId};
@@ -10,8 +10,8 @@ use std::collections::HashMap;
 /// TSA certificate with optional validity period (start, end)
 pub type TsaCertWithValidity = (
     CertificateDer<'static>,
-    Option<DateTime<Utc>>,
-    Option<DateTime<Utc>>,
+    Option<Timestamp>,
+    Option<Timestamp>,
 );
 
 /// A trusted root bundle containing all trust anchors
@@ -279,13 +279,11 @@ impl TrustedRoot {
                     let start = valid_for
                         .start
                         .as_ref()
-                        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
-                        .map(|dt| dt.with_timezone(&Utc));
+                        .and_then(|s| s.parse::<Timestamp>().ok());
                     let end = valid_for
                         .end
                         .as_ref()
-                        .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
-                        .map(|dt| dt.with_timezone(&Utc));
+                        .and_then(|s| s.parse::<Timestamp>().ok());
                     (start, end)
                 } else {
                     (None, None)
@@ -347,20 +345,18 @@ impl TrustedRoot {
     /// Get the validity period for a TSA at a given time
     pub fn tsa_validity_for_time(
         &self,
-        timestamp: DateTime<Utc>,
-    ) -> Result<Option<(DateTime<Utc>, DateTime<Utc>)>> {
+        timestamp: Timestamp,
+    ) -> Result<Option<(Timestamp, Timestamp)>> {
         for tsa in &self.timestamp_authorities {
             if let Some(valid_for) = &tsa.valid_for {
                 let start = valid_for
                     .start
                     .as_ref()
-                    .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
-                    .map(|dt| dt.with_timezone(&Utc));
+                    .and_then(|s| s.parse::<Timestamp>().ok());
                 let end = valid_for
                     .end
                     .as_ref()
-                    .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
-                    .map(|dt| dt.with_timezone(&Utc));
+                    .and_then(|s| s.parse::<Timestamp>().ok());
 
                 // Check if timestamp falls within this TSA's validity
                 if let (Some(start_time), Some(end_time)) = (start, end) {
@@ -387,7 +383,7 @@ impl TrustedRoot {
     ///
     /// Returns false only if there are TSAs with validity constraints and the
     /// timestamp doesn't fall within any of them.
-    pub fn is_timestamp_within_tsa_validity(&self, timestamp: DateTime<Utc>) -> bool {
+    pub fn is_timestamp_within_tsa_validity(&self, timestamp: Timestamp) -> bool {
         // If no TSAs are configured, no validity check needed
         if self.timestamp_authorities.is_empty() {
             return true;
@@ -402,13 +398,11 @@ impl TrustedRoot {
             let start = valid_for
                 .start
                 .as_ref()
-                .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
-                .map(|dt| dt.with_timezone(&Utc));
+                .and_then(|s| s.parse::<Timestamp>().ok());
             let end = valid_for
                 .end
                 .as_ref()
-                .and_then(|s| DateTime::parse_from_rfc3339(s).ok())
-                .map(|dt| dt.with_timezone(&Utc));
+                .and_then(|s| s.parse::<Timestamp>().ok());
 
             // Check if timestamp falls within this TSA's validity period
             let after_start = start.map_or(true, |s| timestamp >= s);

--- a/crates/sigstore-tsa/Cargo.toml
+++ b/crates/sigstore-tsa/Cargo.toml
@@ -33,7 +33,7 @@ rustls-webpki = { workspace = true, default-features = false, features = [
   "std",
 ] }
 rustls-pki-types = { workspace = true, default-features = false }
-chrono = { workspace = true, features = ["std"] }
+jiff = { workspace = true, features = ["std"] }
 tracing = { workspace = true }
 hex = { workspace = true }
 

--- a/crates/sigstore-tsa/src/verify.rs
+++ b/crates/sigstore-tsa/src/verify.rs
@@ -8,10 +8,10 @@
 
 use crate::asn1::{self, PkiStatus, TimeStampResp, TstInfo};
 use crate::error::{Error, Result};
-use jiff::Timestamp;
 use cms::cert::CertificateChoices;
 use cms::signed_data::{SignedData, SignerIdentifier};
 use const_oid::ObjectIdentifier;
+use jiff::Timestamp;
 use rustls_pki_types::CertificateDer;
 use x509_cert::Certificate;
 

--- a/crates/sigstore-tsa/src/verify.rs
+++ b/crates/sigstore-tsa/src/verify.rs
@@ -8,7 +8,7 @@
 
 use crate::asn1::{self, PkiStatus, TimeStampResp, TstInfo};
 use crate::error::{Error, Result};
-use chrono::{DateTime, Utc};
+use jiff::Timestamp;
 use cms::cert::CertificateChoices;
 use cms::signed_data::{SignedData, SignerIdentifier};
 use const_oid::ObjectIdentifier;
@@ -94,7 +94,7 @@ impl Default for VerifyOpts<'_> {
 #[derive(Debug, Clone)]
 pub struct TimestampResult {
     /// The timestamp from the TSA
-    pub time: DateTime<Utc>,
+    pub time: Timestamp,
 }
 
 /// Verify an RFC 3161 timestamp token (ContentInfo).
@@ -204,9 +204,10 @@ pub fn verify_timestamp_response(
     let unix_duration = system_time
         .duration_since(std::time::UNIX_EPOCH)
         .map_err(|_| Error::ParseError("timestamp before epoch".to_string()))?;
-    let timestamp =
-        DateTime::from_timestamp(unix_duration.as_secs() as i64, unix_duration.subsec_nanos())
-            .ok_or_else(|| Error::ParseError("invalid timestamp in TSTInfo".to_string()))?;
+    let seconds = i64::try_from(unix_duration.as_secs())
+        .map_err(|_| Error::ParseError("invalid timestamp in TSTInfo".to_string()))?;
+    let timestamp = Timestamp::new(seconds, unix_duration.subsec_nanos() as i32)
+        .map_err(|_| Error::ParseError("invalid timestamp in TSTInfo".to_string()))?;
 
     tracing::debug!("Extracted timestamp: {}", timestamp);
 
@@ -543,7 +544,7 @@ fn verify_ecdsa_signature(
 /// Validate the TSA certificate chain
 fn validate_tsa_certificate_chain(
     signer_cert: &Certificate,
-    timestamp: DateTime<Utc>,
+    timestamp: Timestamp,
     opts: &VerifyOpts,
     embedded_certs: &[Certificate],
 ) -> Result<()> {
@@ -614,12 +615,12 @@ fn validate_tsa_certificate_chain(
 
     // Convert timestamp to UnixTime for webpki
     let verification_time =
-        UnixTime::since_unix_epoch(std::time::Duration::from_secs(timestamp.timestamp() as u64));
+        UnixTime::since_unix_epoch(std::time::Duration::from_secs(timestamp.as_second() as u64));
 
     tracing::debug!(
         "Verifying certificate chain at timestamp: {} (unix: {})",
         timestamp,
-        timestamp.timestamp()
+        timestamp.as_second()
     );
 
     // Verify the certificate chain with TimeStamping EKU
@@ -719,7 +720,7 @@ mod tests {
         let timestamp_result = result.unwrap();
         // The timestamp should be a valid datetime
         assert!(
-            timestamp_result.time.timestamp() > 0,
+            timestamp_result.time.as_second() > 0,
             "Timestamp should be positive"
         );
     }

--- a/crates/sigstore-types/Cargo.toml
+++ b/crates/sigstore-types/Cargo.toml
@@ -13,7 +13,6 @@ serde_json = { workspace = true }
 base64 = { workspace = true }
 hex = { workspace = true }
 thiserror = { workspace = true }
-chrono = { workspace = true }
 pem = { workspace = true }
 
 [dev-dependencies]

--- a/crates/sigstore-verify/Cargo.toml
+++ b/crates/sigstore-verify/Cargo.toml
@@ -19,7 +19,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_json_canonicalizer = { workspace = true }
 thiserror = { workspace = true }
-chrono = { workspace = true }
+jiff = { workspace = true }
 base64 = { workspace = true }
 x509-cert = { workspace = true }
 hex = { workspace = true }

--- a/crates/sigstore-verify/examples/verify_bundle.rs
+++ b/crates/sigstore-verify/examples/verify_bundle.rs
@@ -235,8 +235,8 @@ fn main() {
                     println!("  Issuer: {}", iss);
                 }
                 if let Some(time) = result.integrated_time {
-                    use chrono::{DateTime, Utc};
-                    if let Some(dt) = DateTime::<Utc>::from_timestamp(time, 0) {
+                    use jiff::Timestamp;
+                    if let Ok(dt) = Timestamp::from_second(time) {
                         println!("  Signed at: {}", dt);
                     }
                 }

--- a/crates/sigstore-verify/examples/verify_conda_attestation.rs
+++ b/crates/sigstore-verify/examples/verify_conda_attestation.rs
@@ -154,8 +154,8 @@ fn main() {
                     println!("  OIDC Issuer: {}", iss);
                 }
                 if let Some(time) = result.integrated_time {
-                    use chrono::{DateTime, Utc};
-                    if let Some(dt) = DateTime::<Utc>::from_timestamp(time, 0) {
+                    use jiff::Timestamp;
+                    if let Ok(dt) = Timestamp::from_second(time) {
                         println!("  Signed at: {}", dt);
                     }
                 }

--- a/crates/sigstore-verify/src/verify_impl/helpers.rs
+++ b/crates/sigstore-verify/src/verify_impl/helpers.rs
@@ -106,7 +106,7 @@ pub fn extract_tsa_timestamp(
             )));
         }
 
-        let timestamp = result.time.timestamp();
+        let timestamp = result.time.as_second();
         any_timestamp_verified = true;
 
         if let Some(earliest) = earliest_timestamp {

--- a/crates/sigstore-verify/src/verify_impl/tlog.rs
+++ b/crates/sigstore-verify/src/verify_impl/tlog.rs
@@ -47,7 +47,7 @@ pub fn verify_tlog_entries(
         let time = entry.integrated_time;
         if time > 0 {
             // Check that integrated time is not in the future (with clock skew tolerance)
-            let now = chrono::Utc::now().timestamp();
+            let now = jiff::Timestamp::now().as_second();
             if time > now + clock_skew_seconds {
                 return Err(Error::Verification(format!(
                     "integrated time {} is in the future (current time: {}, tolerance: {}s)",


### PR DESCRIPTION
#### Summary

This replaces _direct_ usages of `chrono` with `jiff`. Indirect usages are still present via `tough`; I've filed https://github.com/awslabs/tough/issues/942 for that.

See #89 for motivation.

#### Release Note

This will be a breaking change, since the following public APIs previously exposed chrono interfaces (and with this change expose jiff ones instead):

```
sigstore_tsa::TimestampResult::time
sigstore_trust_root::ServiceValidityPeriod
TrustedRoot::tsa_validity_for_time
TrustedRoot::is_timestamp_within_tsa_validity
TsaCertWithValidity
```

#### Documentation

Only generated documentation changes with this.
