### PR TITLE
Bump aws-lc-rs and rustls-webpki

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -109,9 +109,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -120,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -1715,7 +1715,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
@@ -1756,7 +1756,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.13",
+ "rustls-webpki",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -1768,18 +1768,6 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
-
-[[package]]
-name = "rustls-webpki"
-version = "0.102.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
-dependencies = [
- "aws-lc-rs",
- "ring",
- "rustls-pki-types",
- "untrusted 0.9.0",
-]
 
 [[package]]
 name = "rustls-webpki"
@@ -2194,7 +2182,7 @@ dependencies = [
  "rand",
  "reqwest 0.13.3",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki",
  "serde_json",
  "sigstore-crypto",
  "sigstore-types",
@@ -2230,7 +2218,7 @@ dependencies = [
  "pem",
  "regex",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki",
  "serde",
  "serde_json",
  "serde_json_canonicalizer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ base64 = "0.22"
 thiserror = "2.0"
 
 # Cryptography
-aws-lc-rs = "1.15"
+aws-lc-rs = "1.17"
 sha2 = "0.10"
 digest = "0.10"
 signature = "2.2"
@@ -53,7 +53,7 @@ tls_codec = { version = "0.4", default-features = false, features = ["derive"] }
 cms = { version = "0.2", default-features = false }
 x509-tsp = { version = "0.1", default-features = false }
 cmpv2 = { version = "0.2", default-features = false }
-rustls-webpki = { version = "0.102", default-features = false, features = ["alloc", "std", "aws_lc_rs"] }
+rustls-webpki = { version = "0.103", default-features = false, features = ["alloc", "std", "aws-lc-rs"] }
 rustls-pki-types = { version = "1.14", default-features = false, features = ["alloc"] }
 
 # Ambient ID


### PR DESCRIPTION
#### Summary

This debloats the build tree slightly by ensuring that the top-level dependency on rustls-webpki matches the transitive range. I've also bumped aws-lc-rs for good measure.

#### Release Note

No functional changes; internal only.

#### Documentation

No functional changes.
