### PR TITLE
chore: release v0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2039,7 +2039,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-bundle"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64",
  "hex",
@@ -2055,7 +2055,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-cache"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "directories",
  "jiff",
@@ -2067,7 +2067,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-conformance"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64",
  "hex",
@@ -2088,7 +2088,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-crypto"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2109,7 +2109,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-fulcio"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64",
  "hex",
@@ -2127,7 +2127,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-merkle"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64",
  "hex",
@@ -2141,7 +2141,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-oidc"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "ambient-id",
  "base64",
@@ -2159,7 +2159,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-rekor"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64",
  "hex",
@@ -2177,7 +2177,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-sign"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64",
  "hex",
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-trust-root"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64",
  "directories",
@@ -2223,7 +2223,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-tsa"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2249,7 +2249,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-types"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64",
  "hex",
@@ -2261,7 +2261,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-verify"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "base64",
  "cms",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/prefix-dev/sigstore-rust"
@@ -95,15 +95,15 @@ directories = "6.0"
 open = "5.3"
 
 # Internal crates (path + version for publishing)
-sigstore-types = { path = "crates/sigstore-types", version = "0.7.0" }
-sigstore-crypto = { path = "crates/sigstore-crypto", version = "0.7.0" }
-sigstore-merkle = { path = "crates/sigstore-merkle", version = "0.7.0" }
-sigstore-tsa = { path = "crates/sigstore-tsa", version = "0.7.0", default-features = false }
-sigstore-trust-root = { path = "crates/sigstore-trust-root", version = "0.7.0", default-features = false }
-sigstore-bundle = { path = "crates/sigstore-bundle", version = "0.7.0", default-features = false }
-sigstore-rekor = { path = "crates/sigstore-rekor", version = "0.7.0", default-features = false }
-sigstore-fulcio = { path = "crates/sigstore-fulcio", version = "0.7.0", default-features = false }
-sigstore-oidc = { path = "crates/sigstore-oidc", version = "0.7.0", default-features = false }
-sigstore-cache = { path = "crates/sigstore-cache", version = "0.7.0" }
-sigstore-verify = { path = "crates/sigstore-verify", version = "0.7.0", default-features = false }
-sigstore-sign = { path = "crates/sigstore-sign", version = "0.7.0", default-features = false }
+sigstore-types = { path = "crates/sigstore-types", version = "0.8.0" }
+sigstore-crypto = { path = "crates/sigstore-crypto", version = "0.8.0" }
+sigstore-merkle = { path = "crates/sigstore-merkle", version = "0.8.0" }
+sigstore-tsa = { path = "crates/sigstore-tsa", version = "0.8.0", default-features = false }
+sigstore-trust-root = { path = "crates/sigstore-trust-root", version = "0.8.0", default-features = false }
+sigstore-bundle = { path = "crates/sigstore-bundle", version = "0.8.0", default-features = false }
+sigstore-rekor = { path = "crates/sigstore-rekor", version = "0.8.0", default-features = false }
+sigstore-fulcio = { path = "crates/sigstore-fulcio", version = "0.8.0", default-features = false }
+sigstore-oidc = { path = "crates/sigstore-oidc", version = "0.8.0", default-features = false }
+sigstore-cache = { path = "crates/sigstore-cache", version = "0.8.0" }
+sigstore-verify = { path = "crates/sigstore-verify", version = "0.8.0", default-features = false }
+sigstore-sign = { path = "crates/sigstore-sign", version = "0.8.0", default-features = false }

--- a/crates/sigstore-cache/CHANGELOG.md
+++ b/crates/sigstore-cache/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-cache-v0.7.0...sigstore-cache-v0.8.0) - 2026-05-21
+
+### Other
+
+- Replace direct chrono usage with jiff ([#90](https://github.com/sigstore/sigstore-rust/pull/90))
+
 ## [0.3.0](https://github.com/wolfv/sigstore-rust/compare/sigstore-cache-v0.2.0...sigstore-cache-v0.3.0) - 2025-11-28
 
 ### Fixed

--- a/crates/sigstore-crypto/CHANGELOG.md
+++ b/crates/sigstore-crypto/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-crypto-v0.7.0...sigstore-crypto-v0.8.0) - 2026-05-21
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.7.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-crypto-v0.6.6...sigstore-crypto-v0.7.0) - 2026-05-13
 
 ### Other

--- a/crates/sigstore-sign/CHANGELOG.md
+++ b/crates/sigstore-sign/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-sign-v0.7.0...sigstore-sign-v0.8.0) - 2026-05-21
+
+### Other
+
+- Replace direct chrono usage with jiff ([#90](https://github.com/sigstore/sigstore-rust/pull/90))
+
 ## [0.6.5](https://github.com/sigstore/sigstore-rust/compare/sigstore-sign-v0.6.4...sigstore-sign-v0.6.5) - 2026-04-19
 
 ### Other

--- a/crates/sigstore-trust-root/CHANGELOG.md
+++ b/crates/sigstore-trust-root/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-trust-root-v0.7.0...sigstore-trust-root-v0.8.0) - 2026-05-21
+
+### Other
+
+- Replace direct chrono usage with jiff ([#90](https://github.com/sigstore/sigstore-rust/pull/90))
+
 ## [0.7.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-trust-root-v0.6.6...sigstore-trust-root-v0.7.0) - 2026-05-13
 
 ### Added

--- a/crates/sigstore-tsa/CHANGELOG.md
+++ b/crates/sigstore-tsa/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-tsa-v0.7.0...sigstore-tsa-v0.8.0) - 2026-05-21
+
+### Other
+
+- Replace direct chrono usage with jiff ([#90](https://github.com/sigstore/sigstore-rust/pull/90))
+
 ## [0.7.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-tsa-v0.6.6...sigstore-tsa-v0.7.0) - 2026-05-13
 
 ### Added

--- a/crates/sigstore-types/CHANGELOG.md
+++ b/crates/sigstore-types/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-types-v0.7.0...sigstore-types-v0.8.0) - 2026-05-21
+
+### Other
+
+- Replace direct chrono usage with jiff ([#90](https://github.com/sigstore/sigstore-rust/pull/90))
+
 ## [0.6.6](https://github.com/sigstore/sigstore-rust/compare/sigstore-types-v0.6.5...sigstore-types-v0.6.6) - 2026-04-29
 
 ### Fixed

--- a/crates/sigstore-verify/CHANGELOG.md
+++ b/crates/sigstore-verify/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-verify-v0.7.0...sigstore-verify-v0.8.0) - 2026-05-21
+
+### Other
+
+- Replace direct chrono usage with jiff ([#90](https://github.com/sigstore/sigstore-rust/pull/90))
+
 ## [0.7.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-verify-v0.6.6...sigstore-verify-v0.7.0) - 2026-05-13
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `sigstore-types`: 0.7.0 -> 0.7.1 (✓ API compatible changes)
* `sigstore-crypto`: 0.7.0 -> 0.7.1 (✓ API compatible changes)
* `sigstore-merkle`: 0.7.0 -> 0.7.1
* `sigstore-tsa`: 0.7.0 -> 0.7.1 (✓ API compatible changes)
* `sigstore-trust-root`: 0.7.0 -> 0.7.1 (✓ API compatible changes)
* `sigstore-cache`: 0.7.0 -> 0.7.1 (✓ API compatible changes)
* `sigstore-rekor`: 0.7.0 -> 0.7.1
* `sigstore-bundle`: 0.7.0 -> 0.7.1
* `sigstore-oidc`: 0.7.0 -> 0.7.1
* `sigstore-fulcio`: 0.7.0 -> 0.7.1
* `sigstore-verify`: 0.7.0 -> 0.7.1 (✓ API compatible changes)
* `sigstore-sign`: 0.7.0 -> 0.7.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `sigstore-types`

<blockquote>

## [0.7.1](https://github.com/sigstore/sigstore-rust/compare/sigstore-types-v0.7.0...sigstore-types-v0.7.1) - 2026-05-21

### Other

- Replace direct chrono usage with jiff ([#90](https://github.com/sigstore/sigstore-rust/pull/90))
</blockquote>

## `sigstore-crypto`

<blockquote>

## [0.7.1](https://github.com/sigstore/sigstore-rust/compare/sigstore-crypto-v0.7.0...sigstore-crypto-v0.7.1) - 2026-05-21

### Other

- update Cargo.toml dependencies
</blockquote>

## `sigstore-merkle`

<blockquote>

## [0.6.5](https://github.com/sigstore/sigstore-rust/compare/sigstore-merkle-v0.6.4...sigstore-merkle-v0.6.5) - 2026-04-19

### Other

- Fix inclusion proof border length
</blockquote>

## `sigstore-tsa`

<blockquote>

## [0.7.1](https://github.com/sigstore/sigstore-rust/compare/sigstore-tsa-v0.7.0...sigstore-tsa-v0.7.1) - 2026-05-21

### Other

- Replace direct chrono usage with jiff ([#90](https://github.com/sigstore/sigstore-rust/pull/90))
</blockquote>

## `sigstore-trust-root`

<blockquote>

## [0.7.1](https://github.com/sigstore/sigstore-rust/compare/sigstore-trust-root-v0.7.0...sigstore-trust-root-v0.7.1) - 2026-05-21

### Other

- Replace direct chrono usage with jiff ([#90](https://github.com/sigstore/sigstore-rust/pull/90))
</blockquote>

## `sigstore-cache`

<blockquote>

## [0.7.1](https://github.com/sigstore/sigstore-rust/compare/sigstore-cache-v0.7.0...sigstore-cache-v0.7.1) - 2026-05-21

### Other

- Replace direct chrono usage with jiff ([#90](https://github.com/sigstore/sigstore-rust/pull/90))
</blockquote>

## `sigstore-rekor`

<blockquote>

## [0.6.2](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-rekor-v0.6.1...sigstore-rekor-v0.6.2) - 2026-02-04

### Other

- add native-tls feature, bump reqwest ([#51](https://github.com/prefix-dev/sigstore-rust/pull/51))
</blockquote>

## `sigstore-bundle`

<blockquote>

## [0.6.5](https://github.com/sigstore/sigstore-rust/compare/sigstore-bundle-v0.6.4...sigstore-bundle-v0.6.5) - 2026-04-19

### Other

- Allow timestamp-backed bundles without tlog entries ([#80](https://github.com/sigstore/sigstore-rust/pull/80))
</blockquote>

## `sigstore-oidc`

<blockquote>

## [0.7.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-oidc-v0.6.6...sigstore-oidc-v0.7.0) - 2026-05-13

### Added

- trust root update and dependency update ([#85](https://github.com/sigstore/sigstore-rust/pull/85))
</blockquote>

## `sigstore-fulcio`

<blockquote>

## [0.6.2](https://github.com/prefix-dev/sigstore-rust/compare/sigstore-fulcio-v0.6.1...sigstore-fulcio-v0.6.2) - 2026-02-04

### Other

- add native-tls feature, bump reqwest ([#51](https://github.com/prefix-dev/sigstore-rust/pull/51))
</blockquote>

## `sigstore-verify`

<blockquote>

## [0.7.1](https://github.com/sigstore/sigstore-rust/compare/sigstore-verify-v0.7.0...sigstore-verify-v0.7.1) - 2026-05-21

### Other

- Replace direct chrono usage with jiff ([#90](https://github.com/sigstore/sigstore-rust/pull/90))
</blockquote>

## `sigstore-sign`

<blockquote>

## [0.7.1](https://github.com/sigstore/sigstore-rust/compare/sigstore-sign-v0.7.0...sigstore-sign-v0.7.1) - 2026-05-21

### Other

- Replace direct chrono usage with jiff ([#90](https://github.com/sigstore/sigstore-rust/pull/90))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).