### PR TITLE
chore: release v0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-bundle"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "base64",
  "hex",
@@ -1833,7 +1833,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-cache"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "directories",
  "jiff",
@@ -1845,7 +1845,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-conformance"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "base64",
  "hex",
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-crypto"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -1887,7 +1887,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-fulcio"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "base64",
  "hex",
@@ -1905,7 +1905,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-merkle"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "base64",
  "hex",
@@ -1919,7 +1919,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-oidc"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "ambient-id",
  "base64",
@@ -1937,7 +1937,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-rekor"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "base64",
  "hex",
@@ -1955,7 +1955,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-sign"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "base64",
  "hex",
@@ -1977,7 +1977,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-trust-root"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "base64",
  "directories",
@@ -1998,7 +1998,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-tsa"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "aws-lc-rs",
  "base64",
@@ -2024,7 +2024,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-tuf"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "globset",
  "hex",
@@ -2044,7 +2044,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-types"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "base64",
  "hex",
@@ -2056,7 +2056,7 @@ dependencies = [
 
 [[package]]
 name = "sigstore-verify"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "base64",
  "cms",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/prefix-dev/sigstore-rust"
@@ -103,16 +103,16 @@ tempfile = "3.27.0"
 open = "5.3"
 
 # Internal crates (path + version for publishing)
-sigstore-types = { path = "crates/sigstore-types", version = "0.8.0" }
-sigstore-crypto = { path = "crates/sigstore-crypto", version = "0.8.0" }
-sigstore-merkle = { path = "crates/sigstore-merkle", version = "0.8.0" }
-sigstore-tsa = { path = "crates/sigstore-tsa", version = "0.8.0", default-features = false }
-sigstore-trust-root = { path = "crates/sigstore-trust-root", version = "0.8.0", default-features = false }
-sigstore-tuf = { path = "crates/sigstore-tuf", version = "0.8.0", default-features = false }
-sigstore-bundle = { path = "crates/sigstore-bundle", version = "0.8.0", default-features = false }
-sigstore-rekor = { path = "crates/sigstore-rekor", version = "0.8.0", default-features = false }
-sigstore-fulcio = { path = "crates/sigstore-fulcio", version = "0.8.0", default-features = false }
-sigstore-oidc = { path = "crates/sigstore-oidc", version = "0.8.0", default-features = false }
-sigstore-cache = { path = "crates/sigstore-cache", version = "0.8.0" }
-sigstore-verify = { path = "crates/sigstore-verify", version = "0.8.0", default-features = false }
-sigstore-sign = { path = "crates/sigstore-sign", version = "0.8.0", default-features = false }
+sigstore-types = { path = "crates/sigstore-types", version = "0.9.0" }
+sigstore-crypto = { path = "crates/sigstore-crypto", version = "0.9.0" }
+sigstore-merkle = { path = "crates/sigstore-merkle", version = "0.9.0" }
+sigstore-tsa = { path = "crates/sigstore-tsa", version = "0.9.0", default-features = false }
+sigstore-trust-root = { path = "crates/sigstore-trust-root", version = "0.9.0", default-features = false }
+sigstore-tuf = { path = "crates/sigstore-tuf", version = "0.9.0", default-features = false }
+sigstore-bundle = { path = "crates/sigstore-bundle", version = "0.9.0", default-features = false }
+sigstore-rekor = { path = "crates/sigstore-rekor", version = "0.9.0", default-features = false }
+sigstore-fulcio = { path = "crates/sigstore-fulcio", version = "0.9.0", default-features = false }
+sigstore-oidc = { path = "crates/sigstore-oidc", version = "0.9.0", default-features = false }
+sigstore-cache = { path = "crates/sigstore-cache", version = "0.9.0" }
+sigstore-verify = { path = "crates/sigstore-verify", version = "0.9.0", default-features = false }
+sigstore-sign = { path = "crates/sigstore-sign", version = "0.9.0", default-features = false }

--- a/crates/sigstore-bundle/CHANGELOG.md
+++ b/crates/sigstore-bundle/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-bundle-v0.8.0...sigstore-bundle-v0.9.0) - 2026-06-17
+
+### Other
+
+- separate structural validation from crypto verification ([#123](https://github.com/sigstore/sigstore-rust/pull/123))
+- Various improvements ([#109](https://github.com/sigstore/sigstore-rust/pull/109))
+- Support dsse as hashedrekord ([#99](https://github.com/sigstore/sigstore-rust/pull/99))
+
 ## [0.6.5](https://github.com/sigstore/sigstore-rust/compare/sigstore-bundle-v0.6.4...sigstore-bundle-v0.6.5) - 2026-04-19
 
 ### Other

--- a/crates/sigstore-crypto/CHANGELOG.md
+++ b/crates/sigstore-crypto/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-crypto-v0.8.0...sigstore-crypto-v0.9.0) - 2026-06-17
+
+### Other
+
+- harden message-signature verification, drop digest leak ([#119](https://github.com/sigstore/sigstore-rust/pull/119))
+- support sha256/384/512 digests, fail closed on unsupported signing schemes, and add `KeyAlgorithm` ([#109](https://github.com/sigstore/sigstore-rust/pull/109))
+- If a Fulcio OID is found, it must be parseable ([#108](https://github.com/sigstore/sigstore-rust/pull/108))
+
 ## [0.8.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-crypto-v0.7.0...sigstore-crypto-v0.8.0) - 2026-05-21
 
 ### Other

--- a/crates/sigstore-merkle/CHANGELOG.md
+++ b/crates/sigstore-merkle/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-merkle-v0.8.0...sigstore-merkle-v0.9.0) - 2026-06-17
+
+### Other
+
+- fix overflow at maximum tree size ([#116](https://github.com/sigstore/sigstore-rust/pull/116))
+
 ## [0.6.5](https://github.com/sigstore/sigstore-rust/compare/sigstore-merkle-v0.6.4...sigstore-merkle-v0.6.5) - 2026-04-19
 
 ### Other

--- a/crates/sigstore-oidc/CHANGELOG.md
+++ b/crates/sigstore-oidc/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-oidc-v0.8.0...sigstore-oidc-v0.9.0) - 2026-06-17
+
+### Other
+
+- Don't advertize unreliable parsing mechanism ([#118](https://github.com/sigstore/sigstore-rust/pull/118))
+- Include OIDC in signing config, use TUF in examples ([#102](https://github.com/sigstore/sigstore-rust/pull/102))
+
 ## [0.7.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-oidc-v0.6.6...sigstore-oidc-v0.7.0) - 2026-05-13
 
 ### Added

--- a/crates/sigstore-sign/CHANGELOG.md
+++ b/crates/sigstore-sign/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-sign-v0.8.0...sigstore-sign-v0.9.0) - 2026-06-17
+
+### Other
+
+- bump dependencies ([#127](https://github.com/sigstore/sigstore-rust/pull/127))
+- Require complete SigningConfig from tuf ([#117](https://github.com/sigstore/sigstore-rust/pull/117))
+- Don't advertize unreliable parsing mechanism ([#118](https://github.com/sigstore/sigstore-rust/pull/118))
+- Support dsse as hashedrekord ([#99](https://github.com/sigstore/sigstore-rust/pull/99))
+- Include OIDC in signing config, use TUF in examples ([#102](https://github.com/sigstore/sigstore-rust/pull/102))
+
 ## [0.8.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-sign-v0.7.0...sigstore-sign-v0.8.0) - 2026-05-21
 
 ### Other

--- a/crates/sigstore-trust-root/CHANGELOG.md
+++ b/crates/sigstore-trust-root/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-trust-root-v0.8.0...sigstore-trust-root-v0.9.0) - 2026-06-17
+
+### Other
+
+- bump dependencies ([#127](https://github.com/sigstore/sigstore-rust/pull/127))
+- enforce valid_for in key accessors, surface parse errors ([#122](https://github.com/sigstore/sigstore-rust/pull/122))
+- use tempfile and write atomically ([#128](https://github.com/sigstore/sigstore-rust/pull/128))
+- Add sigstore-tuf crate; bootstrap trusted roots over TUF without tough ([#106](https://github.com/sigstore/sigstore-rust/pull/106))
+- refresh embedded TUF data (production root v14 → v15) ([#126](https://github.com/sigstore/sigstore-rust/pull/126))
+- add automation for embedded TUF data updates ([#121](https://github.com/sigstore/sigstore-rust/pull/121))
+
 ## [0.8.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-trust-root-v0.7.0...sigstore-trust-root-v0.8.0) - 2026-05-21
 
 ### Other

--- a/crates/sigstore-tsa/CHANGELOG.md
+++ b/crates/sigstore-tsa/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-tsa-v0.8.0...sigstore-tsa-v0.9.0) - 2026-06-17
+
+### Other
+
+- fail-closed if no root certs provided ([#114](https://github.com/sigstore/sigstore-rust/pull/114))
+- Verify TSA response nonce ([#113](https://github.com/sigstore/sigstore-rust/pull/113))
+- Make our use of jiff more idiomatic ([#100](https://github.com/sigstore/sigstore-rust/pull/100))
+
 ## [0.8.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-tsa-v0.7.0...sigstore-tsa-v0.8.0) - 2026-05-21
 
 ### Other

--- a/crates/sigstore-tuf/CHANGELOG.md
+++ b/crates/sigstore-tuf/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.9.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-tuf-v0.8.0...sigstore-tuf-v0.9.0) - 2026-06-17
+
+### Other
+
+- add crate README ([#131](https://github.com/sigstore/sigstore-rust/pull/131))
+- use tempfile and write atomically ([#128](https://github.com/sigstore/sigstore-rust/pull/128))

--- a/crates/sigstore-types/CHANGELOG.md
+++ b/crates/sigstore-types/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-types-v0.8.0...sigstore-types-v0.9.0) - 2026-06-17
+
+### Other
+
+- harden message-signature verification, drop digest leak ([#119](https://github.com/sigstore/sigstore-rust/pull/119))
+- add `DigestBytes` for multi-algorithm digest encoding ([#109](https://github.com/sigstore/sigstore-rust/pull/109))
+
 ## [0.8.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-types-v0.7.0...sigstore-types-v0.8.0) - 2026-05-21
 
 ### Other

--- a/crates/sigstore-verify/CHANGELOG.md
+++ b/crates/sigstore-verify/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-verify-v0.8.0...sigstore-verify-v0.9.0) - 2026-06-17
+
+### Other
+
+- bump dependencies ([#127](https://github.com/sigstore/sigstore-rust/pull/127))
+- separate structural validation from crypto verification ([#123](https://github.com/sigstore/sigstore-rust/pull/123))
+- enforce valid_for in key accessors, surface parse errors ([#122](https://github.com/sigstore/sigstore-rust/pull/122))
+- Add sigstore-tuf crate; bootstrap trusted roots over TUF without tough ([#106](https://github.com/sigstore/sigstore-rust/pull/106))
+- harden message-signature verification, drop digest leak ([#119](https://github.com/sigstore/sigstore-rust/pull/119))
+- Various improvements ([#109](https://github.com/sigstore/sigstore-rust/pull/109))
+- simplify conformance client using native DSSE validation ([#111](https://github.com/sigstore/sigstore-rust/pull/111))
+- Support dsse as hashedrekord ([#99](https://github.com/sigstore/sigstore-rust/pull/99))
+- Refactor log entry consistency verification ([#103](https://github.com/sigstore/sigstore-rust/pull/103))
+- Include OIDC in signing config, use TUF in examples ([#102](https://github.com/sigstore/sigstore-rust/pull/102))
+
 ## [0.8.0](https://github.com/sigstore/sigstore-rust/compare/sigstore-verify-v0.7.0...sigstore-verify-v0.8.0) - 2026-05-21
 
 ### Other


### PR DESCRIPTION
## 🤖 Release v0.9.0

Workspace-wide bump `0.8.0` → **`0.9.0`**.

> [!IMPORTANT]
> This is a **minor (breaking) release**, not a patch. release-plz/cargo-semver-checks
> initially proposed `0.8.1` and flagged everything as "API compatible", but several
> crates contain breaking changes that the tool does not detect (return-type changes,
> removed constructors). Bumped to `0.9.0` accordingly.

### Breaking changes

* `sigstore-oidc`: `IdentityToken::new()` removed in favor of fallible `from_jwt() -> Result` ([#118](https://github.com/sigstore/sigstore-rust/pull/118))
* `sigstore-trust-root`: validity accessors (incl. `is_timestamp_within_tsa_validity`) now return `Result` ([#122](https://github.com/sigstore/sigstore-rust/pull/122))
* `sigstore-sign`: `SigningConfig::from_tuf_config` now returns `Result` ([#117](https://github.com/sigstore/sigstore-rust/pull/117))
* `sigstore-verify`: per-entry `verify_*_entries` fns replaced by `verify_tlog_consistency` ([#103](https://github.com/sigstore/sigstore-rust/pull/103))

Behavioral changes also ship in `sigstore-tsa` (fail-closed without root certs, [#114](https://github.com/sigstore/sigstore-rust/pull/114)) and `sigstore-crypto`/`sigstore-types` (hardened message-signature verification, [#119](https://github.com/sigstore/sigstore-rust/pull/119)).

### Crates released

`sigstore-types`, `sigstore-crypto`, `sigstore-merkle`, `sigstore-tsa`, `sigstore-tuf`, `sigstore-trust-root`, `sigstore-cache`, `sigstore-rekor`, `sigstore-bundle`, `sigstore-oidc`, `sigstore-fulcio`, `sigstore-verify`, `sigstore-sign` — all `0.9.0`.

<details><summary><i><b>Changelog</b></i></summary>

See each crate's `CHANGELOG.md` for the full list of changes in this release.

</details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/) and adjusted to a minor (breaking) bump.
