### PR TITLE
Include OIDC in signing config, use TUF in examples

### DIFF
--- a/crates/sigstore-oidc/README.md
+++ b/crates/sigstore-oidc/README.md
@@ -30,7 +30,7 @@ Ambient OIDC credentials are detected in CI systems like GitHub: See [ambient-id
 use sigstore_oidc::{get_identity_token, IdentityToken};
 
 // Opens browser (with `browser` feature) or prompts for manual code entry
-let token = get_identity_token().await?;
+let token = get_identity_token(None).await?;
 ```
 
 The `sigstore-sign` crate provides end-to-end signing examples:

--- a/crates/sigstore-oidc/src/oauth.rs
+++ b/crates/sigstore-oidc/src/oauth.rs
@@ -26,6 +26,9 @@ const OOB_REDIRECT_URI: &str = "urn:ietf:wg:oauth:2.0:oob";
 /// Timeout for waiting for the browser callback (5 minutes)
 const CALLBACK_TIMEOUT: Duration = Duration::from_secs(300);
 
+/// Default OIDC provider URL for Sigstore public-good instance
+const DEFAULT_SIGSTORE_OIDC_URL: &str = "https://oauth2.sigstore.dev/auth";
+
 /// OAuth configuration for a provider
 #[derive(Debug, Clone)]
 pub struct OAuthConfig {
@@ -42,9 +45,17 @@ pub struct OAuthConfig {
 impl OAuthConfig {
     /// Create configuration for Sigstore's public OAuth provider
     pub fn sigstore() -> Self {
+        Self::from_oidc_url(DEFAULT_SIGSTORE_OIDC_URL)
+    }
+
+    /// Create configuration for a provider given its base OIDC issuer URL.
+    ///
+    /// This appends `/auth` and `/token` to the base URL.
+    pub fn from_oidc_url(url: &str) -> Self {
+        let base = url.trim_end_matches('/');
         Self {
-            auth_url: "https://oauth2.sigstore.dev/auth/auth".to_string(),
-            token_url: "https://oauth2.sigstore.dev/auth/token".to_string(),
+            auth_url: format!("{}/auth", base),
+            token_url: format!("{}/token", base),
             client_id: "sigstore".to_string(),
             scopes: vec!["openid".to_string(), "email".to_string()],
         }
@@ -169,7 +180,7 @@ impl OAuthClient {
 
     /// Create a client for Sigstore's OAuth provider
     pub fn sigstore() -> Self {
-        Self::new(OAuthConfig::sigstore())
+        Self::new(OAuthConfig::from_oidc_url(DEFAULT_SIGSTORE_OIDC_URL))
     }
 
     /// Generate a PKCE verifier and challenge
@@ -499,29 +510,37 @@ impl OAuthClient {
 ///
 /// #[tokio::main]
 /// async fn main() -> Result<(), Box<dyn std::error::Error>> {
-///     let token = get_identity_token().await?;
+///     let token = get_identity_token(None).await?;
 ///     println!("Got token for: {}", token.subject());
 ///     Ok(())
 /// }
 /// ```
-pub async fn get_identity_token() -> Result<IdentityToken> {
-    OAuthClient::sigstore().auth(DefaultAuthCallback).await
+pub async fn get_identity_token(oidc_url: Option<&str>) -> Result<IdentityToken> {
+    let url = oidc_url.unwrap_or(DEFAULT_SIGSTORE_OIDC_URL);
+    let client = OAuthClient::new(OAuthConfig::from_oidc_url(url));
+    client.auth(DefaultAuthCallback).await
 }
 
 /// Get an identity token with a custom callback for UX customization.
 pub async fn get_identity_token_with_callback(
+    oidc_url: Option<&str>,
     callback: impl AuthCallback,
 ) -> Result<IdentityToken> {
-    OAuthClient::sigstore().auth(callback).await
+    let url = oidc_url.unwrap_or(DEFAULT_SIGSTORE_OIDC_URL);
+    let client = OAuthClient::new(OAuthConfig::from_oidc_url(url));
+    client.auth(callback).await
 }
 
 /// Get an identity token with options.
 ///
 /// Use this to force OOB mode or customize other behavior.
-pub async fn get_identity_token_with_options(options: AuthOptions) -> Result<IdentityToken> {
-    OAuthClient::sigstore()
-        .auth_with_options(DefaultAuthCallback, options)
-        .await
+pub async fn get_identity_token_with_options(
+    oidc_url: Option<&str>,
+    options: AuthOptions,
+) -> Result<IdentityToken> {
+    let url = oidc_url.unwrap_or(DEFAULT_SIGSTORE_OIDC_URL);
+    let client = OAuthClient::new(OAuthConfig::from_oidc_url(url));
+    client.auth_with_options(DefaultAuthCallback, options).await
 }
 
 #[cfg(test)]
@@ -534,6 +553,18 @@ mod tests {
         assert_eq!(config.client_id, "sigstore");
         assert!(config.scopes.contains(&"openid".to_string()));
         assert!(config.scopes.contains(&"email".to_string()));
+    }
+
+    #[test]
+    fn test_oauth_config_from_oidc_url() {
+        let config1 = OAuthConfig::from_oidc_url("https://oauth2.sigstore.dev/auth");
+        assert_eq!(config1.auth_url, "https://oauth2.sigstore.dev/auth/auth");
+        assert_eq!(config1.token_url, "https://oauth2.sigstore.dev/auth/token");
+
+        // Test trailing slash removal
+        let config2 = OAuthConfig::from_oidc_url("https://oauth2.sigstore.dev/auth/");
+        assert_eq!(config2.auth_url, "https://oauth2.sigstore.dev/auth/auth");
+        assert_eq!(config2.token_url, "https://oauth2.sigstore.dev/auth/token");
     }
 
     #[test]

--- a/crates/sigstore-sign/Cargo.toml
+++ b/crates/sigstore-sign/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { workspace = true }
 jiff = { workspace = true }
 serde = { workspace = true }
 hex = { workspace = true }
+sigstore-trust-root = { workspace = true, features = ["tuf"] }
 
 [features]
 default = ["rustls", "browser"]

--- a/crates/sigstore-sign/examples/sign_attestation.rs
+++ b/crates/sigstore-sign/examples/sign_attestation.rs
@@ -137,18 +137,6 @@ async fn main() {
     let package_hash = sigstore_crypto::sha256(&package_bytes);
     println!("  SHA256: {}", hex::encode(package_hash.as_bytes()));
 
-    // Get identity token
-    let identity_token = match get_token(token).await {
-        Ok(t) => t,
-        Err(e) => {
-            eprintln!("Error obtaining identity token: {}", e);
-            process::exit(1);
-        }
-    };
-
-    println!("  Identity: {}", identity_token.subject());
-    println!("  Issuer: {}", identity_token.issuer());
-
     // Get signing config
     let config = if staging {
         println!("  Using: staging infrastructure");
@@ -163,6 +151,18 @@ async fn main() {
     if let Some(ref tsa_url) = config.tsa_url {
         println!("  TSA URL: {}", tsa_url);
     }
+
+    // Get identity token
+    let identity_token = match get_token(token, config.oidc_url.as_deref()).await {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("Error obtaining identity token: {}", e);
+            process::exit(1);
+        }
+    };
+
+    println!("  Identity: {}", identity_token.subject());
+    println!("  Issuer: {}", identity_token.issuer());
 
     // Create attestation using the high-level API
     let predicate = serde_json::json!({
@@ -240,7 +240,7 @@ async fn main() {
     );
 }
 
-async fn get_token(explicit_token: Option<String>) -> Result<IdentityToken, String> {
+async fn get_token(explicit_token: Option<String>, oidc_url: Option<&str>) -> Result<IdentityToken, String> {
     if let Some(token_str) = explicit_token {
         return IdentityToken::from_jwt(&token_str).map_err(|e| format!("Invalid token: {}", e));
     }
@@ -259,9 +259,23 @@ async fn get_token(explicit_token: Option<String>) -> Result<IdentityToken, Stri
     println!("  Starting interactive authentication...");
     println!();
 
-    get_identity_token()
-        .await
-        .map_err(|e| format!("OAuth failed: {}", e))
+    if let Some(url) = oidc_url {
+        let config = sigstore_oidc::OAuthConfig {
+            auth_url: format!("{}/auth", url),
+            token_url: format!("{}/token", url),
+            client_id: "sigstore".to_string(),
+            scopes: vec!["openid".to_string(), "email".to_string()],
+        };
+        let client = sigstore_oidc::OAuthClient::new(config);
+        client
+            .auth(sigstore_oidc::DefaultAuthCallback)
+            .await
+            .map_err(|e| format!("OAuth failed: {}", e))
+    } else {
+        get_identity_token()
+            .await
+            .map_err(|e| format!("OAuth failed: {}", e))
+    }
 }
 
 fn print_usage(program: &str) {

--- a/crates/sigstore-sign/examples/sign_attestation.rs
+++ b/crates/sigstore-sign/examples/sign_attestation.rs
@@ -138,13 +138,18 @@ async fn main() {
     println!("  SHA256: {}", hex::encode(package_hash.as_bytes()));
 
     // Get signing config
-    let config = if staging {
+    let tuf_config = if staging {
         println!("  Using: staging infrastructure");
-        SigningConfig::staging()
+        sigstore_trust_root::SigningConfig::staging()
+            .await
+            .expect("Failed to fetch staging config via TUF")
     } else {
         println!("  Using: production infrastructure");
-        SigningConfig::production()
+        sigstore_trust_root::SigningConfig::production()
+            .await
+            .expect("Failed to fetch production config via TUF")
     };
+    let config = SigningConfig::from_tuf_config(&tuf_config);
 
     println!("  Fulcio URL: {}", config.fulcio_url);
     println!("  Rekor URL: {}", config.rekor_url);

--- a/crates/sigstore-sign/examples/sign_attestation.rs
+++ b/crates/sigstore-sign/examples/sign_attestation.rs
@@ -240,7 +240,10 @@ async fn main() {
     );
 }
 
-async fn get_token(explicit_token: Option<String>, oidc_url: Option<&str>) -> Result<IdentityToken, String> {
+async fn get_token(
+    explicit_token: Option<String>,
+    oidc_url: Option<&str>,
+) -> Result<IdentityToken, String> {
     if let Some(token_str) = explicit_token {
         return IdentityToken::from_jwt(&token_str).map_err(|e| format!("Invalid token: {}", e));
     }
@@ -259,23 +262,9 @@ async fn get_token(explicit_token: Option<String>, oidc_url: Option<&str>) -> Re
     println!("  Starting interactive authentication...");
     println!();
 
-    if let Some(url) = oidc_url {
-        let config = sigstore_oidc::OAuthConfig {
-            auth_url: format!("{}/auth", url),
-            token_url: format!("{}/token", url),
-            client_id: "sigstore".to_string(),
-            scopes: vec!["openid".to_string(), "email".to_string()],
-        };
-        let client = sigstore_oidc::OAuthClient::new(config);
-        client
-            .auth(sigstore_oidc::DefaultAuthCallback)
-            .await
-            .map_err(|e| format!("OAuth failed: {}", e))
-    } else {
-        get_identity_token()
-            .await
-            .map_err(|e| format!("OAuth failed: {}", e))
-    }
+    get_identity_token(oidc_url)
+        .await
+        .map_err(|e| format!("OAuth failed: {}", e))
 }
 
 fn print_usage(program: &str) {

--- a/crates/sigstore-sign/examples/sign_blob.rs
+++ b/crates/sigstore-sign/examples/sign_blob.rs
@@ -232,7 +232,10 @@ async fn main() {
     );
 }
 
-async fn get_token(explicit_token: Option<String>, oidc_url: Option<&str>) -> Result<IdentityToken, String> {
+async fn get_token(
+    explicit_token: Option<String>,
+    oidc_url: Option<&str>,
+) -> Result<IdentityToken, String> {
     // 1. Use explicit token if provided
     if let Some(token_str) = explicit_token {
         return IdentityToken::from_jwt(&token_str).map_err(|e| format!("Invalid token: {}", e));
@@ -252,23 +255,9 @@ async fn get_token(explicit_token: Option<String>, oidc_url: Option<&str>) -> Re
     println!("  Starting interactive authentication...");
     println!();
 
-    if let Some(url) = oidc_url {
-        let config = sigstore_oidc::OAuthConfig {
-            auth_url: format!("{}/auth", url),
-            token_url: format!("{}/token", url),
-            client_id: "sigstore".to_string(),
-            scopes: vec!["openid".to_string(), "email".to_string()],
-        };
-        let client = sigstore_oidc::OAuthClient::new(config);
-        client
-            .auth(sigstore_oidc::DefaultAuthCallback)
-            .await
-            .map_err(|e| format!("OAuth failed: {}", e))
-    } else {
-        get_identity_token()
-            .await
-            .map_err(|e| format!("OAuth failed: {}", e))
-    }
+    get_identity_token(oidc_url)
+        .await
+        .map_err(|e| format!("OAuth failed: {}", e))
 }
 
 fn print_usage(program: &str) {

--- a/crates/sigstore-sign/examples/sign_blob.rs
+++ b/crates/sigstore-sign/examples/sign_blob.rs
@@ -117,22 +117,6 @@ async fn main() {
     println!("Signing artifact: {}", artifact_path);
     println!("  Size: {} bytes", artifact.len());
 
-    // Get identity token
-    let identity_token = match get_token(token).await {
-        Ok(t) => t,
-        Err(e) => {
-            eprintln!("Error obtaining identity token: {}", e);
-            process::exit(1);
-        }
-    };
-
-    // Print token info
-    println!("  Identity: {}", identity_token.subject());
-    if let Some(email) = identity_token.email() {
-        println!("  Email: {}", email);
-    }
-    println!("  Issuer: {}", identity_token.issuer());
-
     // Create signing context with appropriate API version
     let base_config = if staging {
         println!("  Using: staging infrastructure");
@@ -155,6 +139,22 @@ async fn main() {
     } else {
         println!("  TSA URL: (none)");
     }
+
+    // Get identity token
+    let identity_token = match get_token(token, config.oidc_url.as_deref()).await {
+        Ok(t) => t,
+        Err(e) => {
+            eprintln!("Error obtaining identity token: {}", e);
+            process::exit(1);
+        }
+    };
+
+    // Print token info
+    println!("  Identity: {}", identity_token.subject());
+    if let Some(email) = identity_token.email() {
+        println!("  Email: {}", email);
+    }
+    println!("  Issuer: {}", identity_token.issuer());
 
     let context = SigningContext::with_config(config);
 
@@ -232,7 +232,7 @@ async fn main() {
     );
 }
 
-async fn get_token(explicit_token: Option<String>) -> Result<IdentityToken, String> {
+async fn get_token(explicit_token: Option<String>, oidc_url: Option<&str>) -> Result<IdentityToken, String> {
     // 1. Use explicit token if provided
     if let Some(token_str) = explicit_token {
         return IdentityToken::from_jwt(&token_str).map_err(|e| format!("Invalid token: {}", e));
@@ -252,9 +252,23 @@ async fn get_token(explicit_token: Option<String>) -> Result<IdentityToken, Stri
     println!("  Starting interactive authentication...");
     println!();
 
-    get_identity_token()
-        .await
-        .map_err(|e| format!("OAuth failed: {}", e))
+    if let Some(url) = oidc_url {
+        let config = sigstore_oidc::OAuthConfig {
+            auth_url: format!("{}/auth", url),
+            token_url: format!("{}/token", url),
+            client_id: "sigstore".to_string(),
+            scopes: vec!["openid".to_string(), "email".to_string()],
+        };
+        let client = sigstore_oidc::OAuthClient::new(config);
+        client
+            .auth(sigstore_oidc::DefaultAuthCallback)
+            .await
+            .map_err(|e| format!("OAuth failed: {}", e))
+    } else {
+        get_identity_token()
+            .await
+            .map_err(|e| format!("OAuth failed: {}", e))
+    }
 }
 
 fn print_usage(program: &str) {

--- a/crates/sigstore-sign/examples/sign_blob.rs
+++ b/crates/sigstore-sign/examples/sign_blob.rs
@@ -118,13 +118,18 @@ async fn main() {
     println!("  Size: {} bytes", artifact.len());
 
     // Create signing context with appropriate API version
-    let base_config = if staging {
+    let tuf_config = if staging {
         println!("  Using: staging infrastructure");
-        SigningConfig::staging()
+        sigstore_trust_root::SigningConfig::staging()
+            .await
+            .expect("Failed to fetch staging config via TUF")
     } else {
         println!("  Using: production infrastructure");
-        SigningConfig::production()
+        sigstore_trust_root::SigningConfig::production()
+            .await
+            .expect("Failed to fetch production config via TUF")
     };
+    let base_config = SigningConfig::from_tuf_config(&tuf_config);
 
     let config = if use_v2 {
         base_config.with_rekor_version(RekorApiVersion::V2)

--- a/crates/sigstore-sign/src/sign.rs
+++ b/crates/sigstore-sign/src/sign.rs
@@ -33,6 +33,8 @@ pub struct SigningConfig {
     pub signing_scheme: SigningScheme,
     /// Rekor API version to use (defaults to V2)
     pub rekor_api_version: RekorApiVersion,
+    /// OIDC provider URL (optional)
+    pub oidc_url: Option<String>,
 }
 
 impl Default for SigningConfig {
@@ -44,6 +46,7 @@ impl Default for SigningConfig {
             tsa_url: Some("https://timestamp.sigstore.dev/api/v1/timestamp".to_string()),
             signing_scheme: SigningScheme::EcdsaP256Sha256,
             rekor_api_version,
+            oidc_url: Some("https://oauth2.sigstore.dev/auth".to_string()),
         }
     }
 }
@@ -114,6 +117,7 @@ impl SigningConfig {
             };
 
         let tsa_url = tuf_config.get_tsa_url().map(|e| e.url.clone());
+        let oidc_url = tuf_config.get_oidc_url().map(|e| e.url.clone());
 
         Self {
             fulcio_url,
@@ -121,6 +125,7 @@ impl SigningConfig {
             tsa_url,
             signing_scheme: SigningScheme::EcdsaP256Sha256,
             rekor_api_version,
+            oidc_url,
         }
     }
 

--- a/crates/sigstore-verify/Cargo.toml
+++ b/crates/sigstore-verify/Cargo.toml
@@ -42,6 +42,7 @@ const-oid = { workspace = true }
 x509-cert = { workspace = true }
 sigstore-types = { workspace = true }
 regex = { workspace = true }
+sigstore-trust-root = { workspace = true, features = ["tuf"] }
 
 [features]
 default = ["rustls"]

--- a/crates/sigstore-verify/examples/verify_bundle.rs
+++ b/crates/sigstore-verify/examples/verify_bundle.rs
@@ -45,7 +45,7 @@
 //! ```
 
 use regex::Regex;
-use sigstore_trust_root::{TrustedRoot, SIGSTORE_PRODUCTION_TRUSTED_ROOT, SIGSTORE_STAGING_TRUSTED_ROOT};
+use sigstore_trust_root::TrustedRoot;
 use sigstore_types::{Artifact, Bundle, Sha256Hash};
 use sigstore_verify::{verify, VerificationPolicy};
 
@@ -53,7 +53,8 @@ use std::env;
 use std::fs;
 use std::process;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let args: Vec<String> = env::args().collect();
 
     // Parse arguments
@@ -140,19 +141,23 @@ fn main() {
     };
 
     // Load trusted root (staging or production Sigstore infrastructure)
-    let root_json = if staging {
-        println!("  Using: staging infrastructure");
-        SIGSTORE_STAGING_TRUSTED_ROOT
+    let trusted_root = if staging {
+        println!("  Using: staging infrastructure (fetching via TUF)");
+        match TrustedRoot::staging().await {
+            Ok(root) => root,
+            Err(e) => {
+                eprintln!("Error fetching staging trusted root via TUF: {}", e);
+                process::exit(1);
+            }
+        }
     } else {
-        println!("  Using: production infrastructure");
-        SIGSTORE_PRODUCTION_TRUSTED_ROOT
-    };
-
-    let trusted_root = match TrustedRoot::from_json(root_json) {
-        Ok(root) => root,
-        Err(e) => {
-            eprintln!("Error loading trusted root: {}", e);
-            process::exit(1);
+        println!("  Using: production infrastructure (fetching via TUF)");
+        match TrustedRoot::production().await {
+            Ok(root) => root,
+            Err(e) => {
+                eprintln!("Error fetching production trusted root via TUF: {}", e);
+                process::exit(1);
+            }
         }
     };
 

--- a/crates/sigstore-verify/examples/verify_bundle.rs
+++ b/crates/sigstore-verify/examples/verify_bundle.rs
@@ -45,7 +45,7 @@
 //! ```
 
 use regex::Regex;
-use sigstore_trust_root::{TrustedRoot, SIGSTORE_PRODUCTION_TRUSTED_ROOT};
+use sigstore_trust_root::{TrustedRoot, SIGSTORE_PRODUCTION_TRUSTED_ROOT, SIGSTORE_STAGING_TRUSTED_ROOT};
 use sigstore_types::{Artifact, Bundle, Sha256Hash};
 use sigstore_verify::{verify, VerificationPolicy};
 
@@ -60,6 +60,7 @@ fn main() {
     let mut identity: Option<String> = None;
     let mut identity_regexp: Option<String> = None;
     let mut issuer: Option<String> = None;
+    let mut staging = false;
     let mut positional: Vec<String> = Vec::new();
 
     let mut i = 1;
@@ -88,6 +89,9 @@ fn main() {
                     process::exit(1);
                 }
                 issuer = Some(args[i].clone());
+            }
+            "--staging" => {
+                staging = true;
             }
             "--help" | "-h" => {
                 print_usage(&args[0]);
@@ -135,10 +139,16 @@ fn main() {
         }
     };
 
-    // Load trusted root (production Sigstore infrastructure)
-    // Using embedded data for this example - in production, prefer TrustedRoot::production().await
-    // to fetch the latest trust material via TUF protocol
-    let trusted_root = match TrustedRoot::from_json(SIGSTORE_PRODUCTION_TRUSTED_ROOT) {
+    // Load trusted root (staging or production Sigstore infrastructure)
+    let root_json = if staging {
+        println!("  Using: staging infrastructure");
+        SIGSTORE_STAGING_TRUSTED_ROOT
+    } else {
+        println!("  Using: production infrastructure");
+        SIGSTORE_PRODUCTION_TRUSTED_ROOT
+    };
+
+    let trusted_root = match TrustedRoot::from_json(root_json) {
         Ok(root) => root,
         Err(e) => {
             eprintln!("Error loading trusted root: {}", e);
@@ -267,6 +277,7 @@ fn print_usage(program: &str) {
     eprintln!("  --certificate-identity <ID>        Required certificate identity (exact match)");
     eprintln!("  --certificate-identity-regexp <RE> Required certificate identity (regex)");
     eprintln!("  --certificate-oidc-issuer <ISSUER> Required OIDC issuer");
+    eprintln!("  --staging                          Use Sigstore staging infrastructure");
     eprintln!("  -h, --help                         Print this help message");
     eprintln!();
     eprintln!("Aliases (for backwards compatibility):");

--- a/crates/sigstore-verify/examples/verify_conda_attestation.rs
+++ b/crates/sigstore-verify/examples/verify_conda_attestation.rs
@@ -24,7 +24,7 @@
 //!     crates/sigstore-verify/test_data/bundles/conda-attestation.sigstore.json
 //! ```
 
-use sigstore_trust_root::{TrustedRoot, SIGSTORE_PRODUCTION_TRUSTED_ROOT};
+use sigstore_trust_root::TrustedRoot;
 use sigstore_types::{bundle::SignatureContent, Bundle};
 use sigstore_verify::{verify, VerificationPolicy};
 
@@ -32,7 +32,8 @@ use std::env;
 use std::fs;
 use std::process;
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let args: Vec<String> = env::args().collect();
 
     if args.len() != 3 {
@@ -78,12 +79,12 @@ fn main() {
     };
 
     // Load trusted root (production Sigstore infrastructure)
-    // Using embedded data for this example - in production, prefer TrustedRoot::production().await
-    // to fetch the latest trust material via TUF protocol
-    let trusted_root = match TrustedRoot::from_json(SIGSTORE_PRODUCTION_TRUSTED_ROOT) {
+    // Fetching the latest trust material via TUF protocol
+    println!("  Using: production infrastructure (fetching via TUF)");
+    let trusted_root = match TrustedRoot::production().await {
         Ok(root) => root,
         Err(e) => {
-            eprintln!("Error loading trusted root: {}", e);
+            eprintln!("Error fetching production trusted root via TUF: {}", e);
             process::exit(1);
         }
     };


### PR DESCRIPTION
* Include OIDC URL in SigningConfig -- This makes e.g. signing examples work with "--staging" while interactive.
* Support URL argument in get_identity_token() -- This way the oidc usage remains simple even with dynamic URL
* Support "--staging" in the verify example -- this is just a QOL improvement for testing things with the example, not really required
* Examples: Use TUF throughout -- This feels appropriate to me: let's mainly show the usage that is most likely to be correct for most users