### PR TITLE
verify: Refactor log entry consistency verification

### DIFF
--- a/crates/sigstore-verify/src/verify.rs
+++ b/crates/sigstore-verify/src/verify.rs
@@ -415,9 +415,9 @@ impl Verifier {
 
         // (8): Verify the transparency log entry's consistency against the other
         //      materials, to prevent variants of CVE-2022-36056.
-        crate::verify_impl::verify_dsse_entries(bundle)?;
-        crate::verify_impl::verify_intoto_entries(bundle)?;
-        crate::verify_impl::verify_hashedrekord_entries(bundle, &artifact)?;
+        if policy.verify_tlog {
+            crate::verify_impl::verify_tlog_consistency(bundle, &artifact)?;
+        }
 
         Ok(result)
     }

--- a/crates/sigstore-verify/src/verify_impl/hashedrekord.rs
+++ b/crates/sigstore-verify/src/verify_impl/hashedrekord.rs
@@ -13,17 +13,8 @@ use x509_cert::der::Decode;
 use x509_cert::Certificate;
 
 /// Verify artifact hash matches what's in Rekor (for hashedrekord entries)
-pub fn verify_hashedrekord_entries(bundle: &Bundle, artifact: &Artifact<'_>) -> Result<()> {
-    for entry in &bundle.verification_material.tlog_entries {
-        if entry.kind_version.kind == "hashedrekord" {
-            verify_hashedrekord_entry(entry, bundle, artifact)?;
-        }
-    }
-    Ok(())
-}
-
 /// Verify a single hashedrekord entry
-fn verify_hashedrekord_entry(
+pub(crate) fn verify_hashedrekord_entry(
     entry: &TransparencyLogEntry,
     bundle: &Bundle,
     artifact: &Artifact<'_>,

--- a/crates/sigstore-verify/src/verify_impl/mod.rs
+++ b/crates/sigstore-verify/src/verify_impl/mod.rs
@@ -10,5 +10,4 @@ pub(crate) mod sct;
 pub(crate) mod tlog;
 
 // Re-export for use within parent verify.rs
-pub use hashedrekord::verify_hashedrekord_entries;
-pub use rekor::{verify_dsse_entries, verify_intoto_entries};
+pub use rekor::verify_tlog_consistency;

--- a/crates/sigstore-verify/src/verify_impl/rekor.rs
+++ b/crates/sigstore-verify/src/verify_impl/rekor.rs
@@ -8,20 +8,59 @@ use base64::Engine;
 use sigstore_rekor::body::RekorEntryBody;
 use sigstore_types::{Bundle, SignatureContent, TransparencyLogEntry};
 
-/// Verify DSSE envelope matches Rekor entry (for DSSE bundles)
-pub fn verify_dsse_entries(bundle: &Bundle) -> Result<()> {
-    let envelope = match &bundle.content {
-        SignatureContent::DsseEnvelope(env) => env,
-        _ => return Ok(()), // Not a DSSE bundle
-    };
-
+/// Verify that all log entries are consistent with the bundle's content and artifact
+pub fn verify_tlog_consistency(
+    bundle: &Bundle,
+    artifact: &sigstore_types::Artifact<'_>,
+) -> Result<()> {
     for entry in &bundle.verification_material.tlog_entries {
-        if entry.kind_version.kind == "dsse" {
-            match entry.kind_version.version.as_str() {
-                "0.0.1" => verify_dsse_v001(entry, envelope, bundle)?,
-                "0.0.2" => verify_dsse_v002(entry, envelope, bundle)?,
-                _ => {} // Unknown version, skip
-            }
+        match &bundle.content {
+            SignatureContent::DsseEnvelope(envelope) => match entry.kind_version.kind.as_str() {
+                "dsse" => match entry.kind_version.version.as_str() {
+                    "0.0.1" => verify_dsse_v001(entry, envelope, bundle)?,
+                    "0.0.2" => verify_dsse_v002(entry, envelope, bundle)?,
+                    version => {
+                        return Err(Error::Verification(format!(
+                            "unsupported dsse entry version: {}",
+                            version
+                        )))
+                    }
+                },
+                "intoto" => match entry.kind_version.version.as_str() {
+                    "0.0.2" => verify_intoto_v002(entry, envelope)?,
+                    version => {
+                        return Err(Error::Verification(format!(
+                            "unsupported intoto entry version: {}",
+                            version
+                        )))
+                    }
+                },
+                kind => {
+                    return Err(Error::Verification(format!(
+                        "unsupported log entry kind for DSSE envelope: {}",
+                        kind
+                    )))
+                }
+            },
+            SignatureContent::MessageSignature(_) => match entry.kind_version.kind.as_str() {
+                "hashedrekord" => match entry.kind_version.version.as_str() {
+                    "0.0.1" | "0.0.2" => {
+                        super::hashedrekord::verify_hashedrekord_entry(entry, bundle, artifact)?;
+                    }
+                    version => {
+                        return Err(Error::Verification(format!(
+                            "unsupported hashedrekord entry version: {}",
+                            version
+                        )))
+                    }
+                },
+                kind => {
+                    return Err(Error::Verification(format!(
+                        "unsupported log entry kind for MessageSignature: {}",
+                        kind
+                    )))
+                }
+            },
         }
     }
 
@@ -189,22 +228,6 @@ fn verify_dsse_v002(
             return Err(Error::Verification(
                 "DSSE signature in bundle does not match any signature in Rekor entry (signature or verifier mismatch)".to_string(),
             ));
-        }
-    }
-
-    Ok(())
-}
-
-/// Verify DSSE payload matches what's in Rekor (for intoto entries)
-pub fn verify_intoto_entries(bundle: &Bundle) -> Result<()> {
-    let envelope = match &bundle.content {
-        SignatureContent::DsseEnvelope(env) => env,
-        _ => return Ok(()), // Not a DSSE bundle
-    };
-
-    for entry in &bundle.verification_material.tlog_entries {
-        if entry.kind_version.kind == "intoto" {
-            verify_intoto_v002(entry, envelope)?;
         }
     }
 

--- a/crates/sigstore-verify/tests/verification_tests.rs
+++ b/crates/sigstore-verify/tests/verification_tests.rs
@@ -1015,3 +1015,76 @@ fn test_verify_cosign_v3_blob_bundle() {
     let result = verify(artifact, &bundle, &policy, &production_root());
     assert!(result.is_ok(), "Verification failed: {:?}", result.err());
 }
+
+#[test]
+fn test_verify_fails_with_unknown_log_entry_kind() {
+    let mut json_val: serde_json::Value = serde_json::from_str(HAPPY_PATH_V03_BUNDLE_DSSE).unwrap();
+    let mut corrupted_entry = json_val["verificationMaterial"]["tlogEntries"][0].clone();
+    corrupted_entry["kindVersion"]["kind"] = serde_json::json!("unknown_kind");
+    json_val["verificationMaterial"]["tlogEntries"]
+        .as_array_mut()
+        .unwrap()
+        .push(corrupted_entry);
+    let corrupted_bundle_json = serde_json::to_string(&json_val).unwrap();
+
+    let bundle =
+        Bundle::from_json(&corrupted_bundle_json).expect("Failed to parse corrupted bundle");
+    let artifact_digest =
+        extract_artifact_digest(&bundle).expect("Bundle should have artifact digest");
+    let policy = VerificationPolicy::default().skip_timestamp();
+
+    let result = verify(artifact_digest, &bundle, &policy, &production_root());
+    assert!(result.is_err());
+    let err_msg = result.err().unwrap().to_string();
+    assert!(err_msg.contains("unsupported log entry kind"));
+}
+
+#[test]
+fn test_verify_fails_with_unknown_log_entry_version() {
+    let mut json_val: serde_json::Value = serde_json::from_str(HAPPY_PATH_V03_BUNDLE_DSSE).unwrap();
+    let mut corrupted_entry = json_val["verificationMaterial"]["tlogEntries"][0].clone();
+    corrupted_entry["kindVersion"]["version"] = serde_json::json!("9.9.9");
+    json_val["verificationMaterial"]["tlogEntries"]
+        .as_array_mut()
+        .unwrap()
+        .push(corrupted_entry);
+    let corrupted_bundle_json = serde_json::to_string(&json_val).unwrap();
+
+    let bundle =
+        Bundle::from_json(&corrupted_bundle_json).expect("Failed to parse corrupted bundle");
+    let artifact_digest =
+        extract_artifact_digest(&bundle).expect("Bundle should have artifact digest");
+    let policy = VerificationPolicy::default().skip_timestamp();
+
+    let result = verify(artifact_digest, &bundle, &policy, &production_root());
+    assert!(result.is_err());
+    let err_msg = result.err().unwrap().to_string();
+    assert!(
+        err_msg.contains("unsupported dsse entry version")
+            || err_msg.contains("unsupported dsse entry version")
+    );
+}
+
+#[test]
+fn test_verify_fails_with_mismatched_log_entry_kind() {
+    let mut json_val: serde_json::Value = serde_json::from_str(HAPPY_PATH_V03_BUNDLE_DSSE).unwrap();
+    let mut corrupted_entry = json_val["verificationMaterial"]["tlogEntries"][0].clone();
+    corrupted_entry["kindVersion"]["kind"] = serde_json::json!("hashedrekord");
+    corrupted_entry["kindVersion"]["version"] = serde_json::json!("0.0.1");
+    json_val["verificationMaterial"]["tlogEntries"]
+        .as_array_mut()
+        .unwrap()
+        .push(corrupted_entry);
+    let corrupted_bundle_json = serde_json::to_string(&json_val).unwrap();
+
+    let bundle =
+        Bundle::from_json(&corrupted_bundle_json).expect("Failed to parse corrupted bundle");
+    let artifact_digest =
+        extract_artifact_digest(&bundle).expect("Bundle should have artifact digest");
+    let policy = VerificationPolicy::default().skip_timestamp();
+
+    let result = verify(artifact_digest, &bundle, &policy, &production_root());
+    assert!(result.is_err());
+    let err_msg = result.err().unwrap().to_string();
+    assert!(err_msg.contains("unsupported log entry kind for DSSE envelope"));
+}


### PR DESCRIPTION
Verify that
1. We understand each entry (kind and version)
2. Each entry matches the bundle material

The old code seemingly only verified the second part if we happened to recognise the entry type (unknown types and versions were just skipped)

Additionally, only runs this code if policy includes "verify_tlog".
