### PR TITLE
crypto: If a Fulcio OID is found, it must be parseable

### DIFF
--- a/crates/sigstore-crypto/src/x509.rs
+++ b/crates/sigstore-crypto/src/x509.rs
@@ -184,6 +184,10 @@ pub fn extract_fulcio_issuer(cert: &Certificate) -> Result<Option<String>> {
             if let Ok(s) = std::str::from_utf8(value_bytes) {
                 return Ok(Some(s.to_string()));
             }
+
+            return Err(Error::InvalidCertificate(
+                "malformed Fulcio issuer extension".to_string(),
+            ));
         }
     }
 


### PR DESCRIPTION
This seems like the right thing to do if FULCIO_ISSUER_OID is found but we can't understand it