### PR TITLE
crypto: Various improvements

### DIFF
--- a/crates/sigstore-bundle/src/builder.rs
+++ b/crates/sigstore-bundle/src/builder.rs
@@ -75,7 +75,7 @@ impl BundleV03 {
             SignatureContent::MessageSignature(MessageSignature {
                 message_digest: Some(sigstore_types::bundle::MessageDigest {
                     algorithm: sigstore_types::HashAlgorithm::Sha2256,
-                    digest: artifact_digest,
+                    digest: artifact_digest.into(),
                 }),
                 signature,
             }),

--- a/crates/sigstore-crypto/src/hash.rs
+++ b/crates/sigstore-crypto/src/hash.rs
@@ -1,6 +1,6 @@
 //! Hashing utilities using aws-lc-rs
 
-use aws_lc_rs::digest::{self, Context, SHA256};
+use aws_lc_rs::digest::{self, Context, SHA256, SHA384, SHA512};
 use sigstore_types::Sha256Hash;
 use std::io::{self, Read};
 
@@ -10,6 +10,18 @@ pub fn sha256(data: &[u8]) -> Sha256Hash {
     let mut result = [0u8; 32];
     result.copy_from_slice(digest.as_ref());
     Sha256Hash::from_bytes(result)
+}
+
+/// Hash data using SHA-384, returning raw bytes
+pub fn sha384(data: &[u8]) -> Vec<u8> {
+    let digest = digest::digest(&SHA384, data);
+    digest.as_ref().to_vec()
+}
+
+/// Hash data using SHA-512, returning raw bytes
+pub fn sha512(data: &[u8]) -> Vec<u8> {
+    let digest = digest::digest(&SHA512, data);
+    digest.as_ref().to_vec()
 }
 
 /// Incremental SHA-256 hasher

--- a/crates/sigstore-crypto/src/lib.rs
+++ b/crates/sigstore-crypto/src/lib.rs
@@ -16,7 +16,7 @@ pub use checkpoint::{
     verify_signature_auto, Checkpoint, CheckpointSignature, CheckpointVerifyExt, KeyType,
 };
 pub use error::{Error, Result};
-pub use hash::{sha256, sha256_reader, Sha256Hasher};
+pub use hash::{sha256, sha256_reader, sha384, sha512, Sha256Hasher};
 pub use keyring::Keyring;
 pub use signing::{KeyPair, SigningScheme};
 pub use verification::{verify_signature, verify_signature_prehashed, VerificationKey};

--- a/crates/sigstore-crypto/src/lib.rs
+++ b/crates/sigstore-crypto/src/lib.rs
@@ -18,6 +18,6 @@ pub use checkpoint::{
 pub use error::{Error, Result};
 pub use hash::{sha256, sha256_reader, sha384, sha512, Sha256Hasher};
 pub use keyring::Keyring;
-pub use signing::{KeyPair, SigningScheme};
+pub use signing::{KeyAlgorithm, KeyPair, SigningScheme};
 pub use verification::{verify_signature, verify_signature_prehashed, VerificationKey};
 pub use x509::{parse_certificate_info, CertificateInfo};

--- a/crates/sigstore-crypto/src/signing.rs
+++ b/crates/sigstore-crypto/src/signing.rs
@@ -17,6 +17,8 @@ pub enum SigningScheme {
     EcdsaP256Sha256,
     /// ECDSA P-256 with SHA-384 (non-standard but valid)
     EcdsaP256Sha384,
+    /// ECDSA P-384 with SHA-256
+    EcdsaP384Sha256,
     /// ECDSA P-384 with SHA-384
     EcdsaP384Sha384,
     /// Ed25519
@@ -41,6 +43,7 @@ impl SigningScheme {
         match self {
             SigningScheme::EcdsaP256Sha256 => "ECDSA_P256_SHA256",
             SigningScheme::EcdsaP256Sha384 => "ECDSA_P256_SHA384",
+            SigningScheme::EcdsaP384Sha256 => "ECDSA_P384_SHA256",
             SigningScheme::EcdsaP384Sha384 => "ECDSA_P384_SHA384",
             SigningScheme::Ed25519 => "ED25519",
             SigningScheme::RsaPssSha256 => "RSA_PSS_SHA256",
@@ -52,30 +55,68 @@ impl SigningScheme {
         }
     }
 
-    /// Check if this scheme uses SHA-256 for its signature hash.
-    ///
-    /// This is relevant for hashedrekord verification: Rekor always stores SHA-256
-    /// hashes, so only schemes that use SHA-256 can be verified with prehashed
-    /// verification when only the digest is available (not the original artifact).
-    ///
-    /// - Schemes using SHA-256: Can use `verify_signature_prehashed` with Rekor's hash
-    /// - Schemes using SHA-384/512: Cannot use prehashed verification (hash mismatch)
-    /// - Ed25519: Doesn't support prehashed mode
-    pub fn uses_sha256(&self) -> bool {
-        matches!(
-            self,
-            SigningScheme::EcdsaP256Sha256
-                | SigningScheme::RsaPssSha256
-                | SigningScheme::RsaPkcs1Sha256
-        )
-    }
-
     /// Check if this scheme supports prehashed verification.
     ///
     /// Ed25519 doesn't support prehashed verification (it signs the full message).
     /// ECDSA and RSA schemes support prehashed verification.
     pub fn supports_prehashed(&self) -> bool {
         !matches!(self, SigningScheme::Ed25519)
+    }
+}
+
+/// Key algorithm derived from the certificate/public key
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeyAlgorithm {
+    /// ECDSA P-256
+    EcdsaP256,
+    /// ECDSA P-384
+    EcdsaP384,
+    /// Ed25519
+    Ed25519,
+    /// RSA
+    Rsa,
+}
+
+impl KeyAlgorithm {
+    /// Get the default signing scheme for this key algorithm
+    pub fn default_signing_scheme(&self) -> SigningScheme {
+        match self {
+            KeyAlgorithm::EcdsaP256 => SigningScheme::EcdsaP256Sha256,
+            KeyAlgorithm::EcdsaP384 => SigningScheme::EcdsaP384Sha384,
+            KeyAlgorithm::Ed25519 => SigningScheme::Ed25519,
+            KeyAlgorithm::Rsa => SigningScheme::RsaPkcs1Sha256,
+        }
+    }
+
+    /// Resolve the signing scheme using the key algorithm and a specific hash algorithm
+    pub fn resolve_signing_scheme(
+        &self,
+        hash_algo: sigstore_types::HashAlgorithm,
+    ) -> Result<SigningScheme> {
+        match self {
+            KeyAlgorithm::EcdsaP256 => match hash_algo {
+                sigstore_types::HashAlgorithm::Sha2256 => Ok(SigningScheme::EcdsaP256Sha256),
+                sigstore_types::HashAlgorithm::Sha2384 => Ok(SigningScheme::EcdsaP256Sha384),
+                _ => Err(Error::UnsupportedAlgorithm(format!(
+                    "ECDSA P-256 does not support hash algorithm {:?}",
+                    hash_algo
+                ))),
+            },
+            KeyAlgorithm::EcdsaP384 => match hash_algo {
+                sigstore_types::HashAlgorithm::Sha2256 => Ok(SigningScheme::EcdsaP384Sha256),
+                sigstore_types::HashAlgorithm::Sha2384 => Ok(SigningScheme::EcdsaP384Sha384),
+                _ => Err(Error::UnsupportedAlgorithm(format!(
+                    "ECDSA P-384 does not support hash algorithm {:?}",
+                    hash_algo
+                ))),
+            },
+            KeyAlgorithm::Ed25519 => Ok(SigningScheme::Ed25519),
+            KeyAlgorithm::Rsa => match hash_algo {
+                sigstore_types::HashAlgorithm::Sha2256 => Ok(SigningScheme::RsaPkcs1Sha256),
+                sigstore_types::HashAlgorithm::Sha2384 => Ok(SigningScheme::RsaPkcs1Sha384),
+                sigstore_types::HashAlgorithm::Sha2512 => Ok(SigningScheme::RsaPkcs1Sha512),
+            },
+        }
     }
 }
 

--- a/crates/sigstore-crypto/src/verification.rs
+++ b/crates/sigstore-crypto/src/verification.rs
@@ -3,9 +3,10 @@
 use crate::error::{Error, Result};
 use crate::signing::SigningScheme;
 use aws_lc_rs::signature::{
-    UnparsedPublicKey, ECDSA_P256_SHA256_ASN1, ECDSA_P256_SHA384_ASN1, ECDSA_P384_SHA384_ASN1,
-    ED25519, RSA_PKCS1_2048_8192_SHA256, RSA_PKCS1_2048_8192_SHA384, RSA_PKCS1_2048_8192_SHA512,
-    RSA_PSS_2048_8192_SHA256, RSA_PSS_2048_8192_SHA384, RSA_PSS_2048_8192_SHA512,
+    UnparsedPublicKey, ECDSA_P256_SHA256_ASN1, ECDSA_P256_SHA384_ASN1, ECDSA_P384_SHA256_ASN1,
+    ECDSA_P384_SHA384_ASN1, ED25519, RSA_PKCS1_2048_8192_SHA256, RSA_PKCS1_2048_8192_SHA384,
+    RSA_PKCS1_2048_8192_SHA512, RSA_PSS_2048_8192_SHA256, RSA_PSS_2048_8192_SHA384,
+    RSA_PSS_2048_8192_SHA512,
 };
 use sigstore_types::{DerPublicKey, SignatureBytes};
 use spki::SubjectPublicKeyInfoRef;
@@ -63,6 +64,12 @@ impl VerificationKey {
                 let key = UnparsedPublicKey::new(&ECDSA_P256_SHA384_ASN1, &self.bytes);
                 key.verify(data, signature).map_err(|_| {
                     Error::Verification("ECDSA P-256 SHA-384 signature invalid".to_string())
+                })
+            }
+            SigningScheme::EcdsaP384Sha256 => {
+                let key = UnparsedPublicKey::new(&ECDSA_P384_SHA256_ASN1, &self.bytes);
+                key.verify(data, signature).map_err(|_| {
+                    Error::Verification("ECDSA P-384 SHA-256 signature invalid".to_string())
                 })
             }
             SigningScheme::EcdsaP384Sha384 => {
@@ -130,6 +137,7 @@ impl VerificationKey {
         ) = match self.scheme {
             SigningScheme::EcdsaP256Sha256 => (&SHA256, &ECDSA_P256_SHA256_ASN1),
             SigningScheme::EcdsaP256Sha384 => (&SHA384, &ECDSA_P256_SHA384_ASN1),
+            SigningScheme::EcdsaP384Sha256 => (&SHA256, &ECDSA_P384_SHA256_ASN1),
             SigningScheme::EcdsaP384Sha384 => (&SHA384, &ECDSA_P384_SHA384_ASN1),
             SigningScheme::RsaPssSha256 => (&SHA256, &RSA_PSS_2048_8192_SHA256),
             SigningScheme::RsaPssSha384 => (&SHA384, &RSA_PSS_2048_8192_SHA384),
@@ -145,8 +153,13 @@ impl VerificationKey {
             }
         };
 
-        let aws_digest = Digest::import_less_safe(digest, aws_algo)
-            .map_err(|_| Error::Verification("Failed to import digest".to_string()))?;
+        let aws_digest = Digest::import_less_safe(digest, aws_algo).map_err(|_| {
+            Error::Verification(format!(
+                "Failed to import digest: len={}, algo_expected_len={}",
+                digest.len(),
+                aws_algo.output_len
+            ))
+        })?;
 
         let key = UnparsedPublicKey::new(asn1_algo, &self.bytes);
         key.verify_digest(&aws_digest, signature.as_bytes())

--- a/crates/sigstore-crypto/src/verification.rs
+++ b/crates/sigstore-crypto/src/verification.rs
@@ -7,7 +7,7 @@ use aws_lc_rs::signature::{
     ED25519, RSA_PKCS1_2048_8192_SHA256, RSA_PKCS1_2048_8192_SHA384, RSA_PKCS1_2048_8192_SHA512,
     RSA_PSS_2048_8192_SHA256, RSA_PSS_2048_8192_SHA384, RSA_PSS_2048_8192_SHA512,
 };
-use sigstore_types::{DerPublicKey, Sha256Hash, SignatureBytes};
+use sigstore_types::{DerPublicKey, SignatureBytes};
 use spki::SubjectPublicKeyInfoRef;
 
 /// A public key for verification
@@ -115,31 +115,42 @@ impl VerificationKey {
         }
     }
 
-    /// Verify a signature over prehashed data (SHA-256)
+    /// Verify a signature over prehashed data
     ///
     /// This is used for hashedrekord verification where the signature is over
-    /// the SHA-256 hash of the artifact, not the artifact itself.
-    pub fn verify_prehashed(&self, digest: &Sha256Hash, signature: &SignatureBytes) -> Result<()> {
-        use aws_lc_rs::digest::{Digest, SHA256};
+    /// a pre-computed hash of the artifact, not the artifact itself.
+    pub fn verify_prehashed(&self, digest: &[u8], signature: &SignatureBytes) -> Result<()> {
+        use aws_lc_rs::digest::{Digest, SHA256, SHA384, SHA512};
+        use aws_lc_rs::signature::VerificationAlgorithm;
 
-        match self.scheme {
-            SigningScheme::EcdsaP256Sha256 => {
-                let aws_digest = Digest::import_less_safe(digest.as_slice(), &SHA256)
-                    .map_err(|_| Error::Verification("Failed to import digest".to_string()))?;
-
-                let key = UnparsedPublicKey::new(&ECDSA_P256_SHA256_ASN1, &self.bytes);
-                key.verify_digest(&aws_digest, signature.as_bytes())
-                    .map_err(|_| Error::Verification("ECDSA P-256 signature invalid".to_string()))
-            }
-            SigningScheme::Ed25519 => {
-                // Ed25519 doesn't support prehashed mode - verify directly over digest bytes
-                self.verify_inner(digest.as_slice(), signature.as_bytes())
-            }
+        // Determine the expected hash algorithm and ASN.1 algorithm from the SigningScheme
+        let (aws_algo, asn1_algo): (
+            &aws_lc_rs::digest::Algorithm,
+            &'static dyn VerificationAlgorithm,
+        ) = match self.scheme {
+            SigningScheme::EcdsaP256Sha256 => (&SHA256, &ECDSA_P256_SHA256_ASN1),
+            SigningScheme::EcdsaP256Sha384 => (&SHA384, &ECDSA_P256_SHA384_ASN1),
+            SigningScheme::EcdsaP384Sha384 => (&SHA384, &ECDSA_P384_SHA384_ASN1),
+            SigningScheme::RsaPssSha256 => (&SHA256, &RSA_PSS_2048_8192_SHA256),
+            SigningScheme::RsaPssSha384 => (&SHA384, &RSA_PSS_2048_8192_SHA384),
+            SigningScheme::RsaPssSha512 => (&SHA512, &RSA_PSS_2048_8192_SHA512),
+            SigningScheme::RsaPkcs1Sha256 => (&SHA256, &RSA_PKCS1_2048_8192_SHA256),
+            SigningScheme::RsaPkcs1Sha384 => (&SHA384, &RSA_PKCS1_2048_8192_SHA384),
+            SigningScheme::RsaPkcs1Sha512 => (&SHA512, &RSA_PKCS1_2048_8192_SHA512),
             _ => {
-                // For other schemes, verify directly over digest bytes
-                self.verify_inner(digest.as_slice(), signature.as_bytes())
+                return Err(Error::UnsupportedAlgorithm(format!(
+                    "Scheme {:?} does not support prehashed mode",
+                    self.scheme
+                )));
             }
-        }
+        };
+
+        let aws_digest = Digest::import_less_safe(digest, aws_algo)
+            .map_err(|_| Error::Verification("Failed to import digest".to_string()))?;
+
+        let key = UnparsedPublicKey::new(asn1_algo, &self.bytes);
+        key.verify_digest(&aws_digest, signature.as_bytes())
+            .map_err(|e| Error::Verification(format!("Signature invalid: {}", e)))
     }
 }
 
@@ -165,16 +176,16 @@ pub fn verify_signature(
 /// Verify a signature over prehashed data using the specified scheme
 ///
 /// This is used for hashedrekord verification where the signature is over
-/// the SHA-256 hash of the artifact, not the artifact itself.
+/// a pre-computed hash of the artifact, not the artifact itself.
 ///
 /// # Arguments
 /// * `public_key` - DER-encoded SPKI public key
-/// * `digest` - SHA-256 hash of the artifact
+/// * `digest` - Pre-computed hash of the artifact
 /// * `signature` - The signature to verify
 /// * `scheme` - The signing scheme used
 pub fn verify_signature_prehashed(
     public_key: &DerPublicKey,
-    digest: &Sha256Hash,
+    digest: &[u8],
     signature: &SignatureBytes,
     scheme: SigningScheme,
 ) -> Result<()> {
@@ -217,5 +228,35 @@ mod tests {
         let pubkey = kp.public_key_der().unwrap();
         let vk = VerificationKey::from_spki(&pubkey, kp.default_scheme()).unwrap();
         assert!(vk.verify(b"wrong data", &sig).is_err());
+    }
+
+    #[test]
+    fn test_verify_prehashed_ecdsa_p256() {
+        let kp = KeyPair::generate_ecdsa_p256().unwrap();
+        let data = b"test data to prehash";
+        let sig = kp.sign(data).unwrap();
+        let digest = crate::hash::sha256(data);
+
+        let pubkey = kp.public_key_der().unwrap();
+        let vk = VerificationKey::from_spki(&pubkey, kp.default_scheme()).unwrap();
+        assert!(vk.verify_prehashed(digest.as_bytes(), &sig).is_ok());
+    }
+
+    #[test]
+    fn test_verify_prehashed_unsupported() {
+        // Construct a VerificationKey directly with Ed25519 which doesn't support prehashed
+        let vk = VerificationKey {
+            bytes: vec![0u8; 32],
+            scheme: SigningScheme::Ed25519,
+        };
+        let dummy_digest = vec![0u8; 32];
+        let dummy_sig = SignatureBytes::new(vec![0u8; 64]);
+
+        let result = vk.verify_prehashed(&dummy_digest, &dummy_sig);
+        assert!(result.is_err());
+        assert!(matches!(
+            result.unwrap_err(),
+            Error::UnsupportedAlgorithm(_)
+        ));
     }
 }

--- a/crates/sigstore-crypto/src/x509.rs
+++ b/crates/sigstore-crypto/src/x509.rs
@@ -4,7 +4,7 @@
 //! from X.509 certificates used in Sigstore bundles.
 
 use crate::error::{Error, Result};
-use crate::SigningScheme;
+use crate::KeyAlgorithm;
 use sigstore_types::DerPublicKey;
 use x509_cert::der::{Decode, Encode};
 use x509_cert::Certificate;
@@ -31,8 +31,8 @@ pub struct CertificateInfo {
     pub not_after: i64,
     /// Public key in DER-encoded SPKI format
     pub public_key: DerPublicKey,
-    /// Signing scheme derived from the public key algorithm
-    pub signing_scheme: SigningScheme,
+    /// Key algorithm derived from the public key algorithm
+    pub key_algorithm: KeyAlgorithm,
 }
 
 /// Parse certificate information from DER-encoded certificate
@@ -63,8 +63,8 @@ pub fn parse_certificate_info(cert_der: &[u8]) -> Result<CertificateInfo> {
         .map_err(|e| Error::InvalidCertificate(format!("failed to encode SPKI: {}", e)))?;
     let public_key = DerPublicKey::new(public_key_der);
 
-    // Determine signing scheme from algorithm OID and parameters
-    let signing_scheme = determine_signing_scheme(public_key_info)?;
+    // Determine key algorithm from algorithm OID and parameters
+    let key_algorithm = determine_key_algorithm(public_key_info)?;
 
     // Extract identity from SAN extension
     let identity = extract_san_identity(&cert)?;
@@ -78,14 +78,14 @@ pub fn parse_certificate_info(cert_der: &[u8]) -> Result<CertificateInfo> {
         not_before,
         not_after,
         public_key,
-        signing_scheme,
+        key_algorithm,
     })
 }
 
-/// Determine the signing scheme from SubjectPublicKeyInfo
-fn determine_signing_scheme(
+/// Determine the key algorithm from SubjectPublicKeyInfo
+fn determine_key_algorithm(
     spki: &x509_cert::spki::SubjectPublicKeyInfoOwned,
-) -> Result<SigningScheme> {
+) -> Result<KeyAlgorithm> {
     let alg_oid = spki.algorithm.oid;
 
     if alg_oid == ID_EC_PUBLIC_KEY {
@@ -98,9 +98,9 @@ fn determine_signing_scheme(
             })?;
 
             if curve_oid == SECP_256_R_1 {
-                return Ok(SigningScheme::EcdsaP256Sha256);
+                return Ok(KeyAlgorithm::EcdsaP256);
             } else if curve_oid == SECP_384_R_1 {
-                return Ok(SigningScheme::EcdsaP384Sha384);
+                return Ok(KeyAlgorithm::EcdsaP384);
             } else {
                 return Err(Error::InvalidCertificate(format!(
                     "unsupported EC curve OID: {}",
@@ -113,11 +113,9 @@ fn determine_signing_scheme(
             ));
         }
     } else if alg_oid == RSA_ENCRYPTION {
-        // RSA key - default to RSA PKCS#1 SHA-256
-        // We can't determine padding from the certificate alone
-        return Ok(SigningScheme::RsaPkcs1Sha256);
+        return Ok(KeyAlgorithm::Rsa);
     } else if alg_oid == ID_ED_25519 {
-        return Ok(SigningScheme::Ed25519);
+        return Ok(KeyAlgorithm::Ed25519);
     }
 
     Err(Error::InvalidCertificate(format!(

--- a/crates/sigstore-types/src/artifact.rs
+++ b/crates/sigstore-types/src/artifact.rs
@@ -10,7 +10,7 @@ use crate::Sha256Hash;
 ///
 /// This enum allows flexible input for signing and verification operations:
 /// - `Bytes`: Raw artifact bytes (hash will be computed internally)
-/// - `Digest`: Pre-computed SHA-256 digest (no raw bytes needed)
+/// - `Digest`: Pre-computed digest (no raw bytes needed)
 ///
 /// # Example
 ///
@@ -30,8 +30,8 @@ use crate::Sha256Hash;
 pub enum Artifact<'a> {
     /// Raw artifact bytes (hash will be computed)
     Bytes(&'a [u8]),
-    /// Pre-computed SHA-256 digest
-    Digest(Sha256Hash),
+    /// Pre-computed digest bytes
+    Digest(&'a [u8]),
 }
 
 impl<'a> Artifact<'a> {
@@ -41,7 +41,7 @@ impl<'a> Artifact<'a> {
     }
 
     /// Create an artifact from a pre-computed digest
-    pub fn from_digest(digest: Sha256Hash) -> Self {
+    pub fn from_digest(digest: &'a [u8]) -> Self {
         Artifact::Digest(digest)
     }
 
@@ -58,8 +58,8 @@ impl<'a> Artifact<'a> {
         }
     }
 
-    /// Get the pre-computed digest if available
-    pub fn pre_computed_digest(&self) -> Option<Sha256Hash> {
+    /// Get the pre-computed digest bytes if available
+    pub fn pre_computed_digest(&self) -> Option<&[u8]> {
         match self {
             Artifact::Bytes(_) => None,
             Artifact::Digest(hash) => Some(*hash),
@@ -85,9 +85,18 @@ impl<'a, const N: usize> From<&'a [u8; N]> for Artifact<'a> {
     }
 }
 
+impl<'a> From<&'a Sha256Hash> for Artifact<'a> {
+    fn from(hash: &'a Sha256Hash) -> Self {
+        Artifact::Digest(hash.as_bytes())
+    }
+}
+
 impl From<Sha256Hash> for Artifact<'static> {
     fn from(hash: Sha256Hash) -> Self {
-        Artifact::Digest(hash)
+        // Warning: This creates a memory leak to provide a 'static reference
+        // This is kept for backwards compatibility with the previous API
+        let bytes: &'static [u8] = Box::leak(Box::new(*hash.as_bytes()));
+        Artifact::Digest(bytes)
     }
 }
 
@@ -112,5 +121,9 @@ mod tests {
         let artifact = Artifact::from(digest);
         assert!(!artifact.has_bytes());
         assert_eq!(artifact.bytes(), None);
+        assert_eq!(
+            artifact.pre_computed_digest(),
+            Some(digest.as_bytes().as_slice())
+        );
     }
 }

--- a/crates/sigstore-types/src/artifact.rs
+++ b/crates/sigstore-types/src/artifact.rs
@@ -140,9 +140,6 @@ mod tests {
         let artifact = Artifact::from(&digest);
         assert!(!artifact.has_bytes());
         assert_eq!(artifact.bytes(), None);
-        assert_eq!(
-            artifact.pre_computed_digest(),
-            Some(raw_bytes.as_slice())
-        );
+        assert_eq!(artifact.pre_computed_digest(), Some(raw_bytes.as_slice()));
     }
 }

--- a/crates/sigstore-types/src/artifact.rs
+++ b/crates/sigstore-types/src/artifact.rs
@@ -4,7 +4,7 @@
 //! Artifacts can be provided as raw bytes or as pre-computed digests, allowing
 //! for efficient handling of large files without loading them entirely into memory.
 
-use crate::Sha256Hash;
+use crate::{DigestBytes, Sha256Hash};
 
 /// An artifact to be signed or verified
 ///
@@ -91,6 +91,12 @@ impl<'a> From<&'a Sha256Hash> for Artifact<'a> {
     }
 }
 
+impl<'a> From<&'a DigestBytes> for Artifact<'a> {
+    fn from(digest: &'a DigestBytes) -> Self {
+        Artifact::Digest(digest.as_bytes())
+    }
+}
+
 impl From<Sha256Hash> for Artifact<'static> {
     fn from(hash: Sha256Hash) -> Self {
         // Warning: This creates a memory leak to provide a 'static reference
@@ -124,6 +130,19 @@ mod tests {
         assert_eq!(
             artifact.pre_computed_digest(),
             Some(digest.as_bytes().as_slice())
+        );
+    }
+
+    #[test]
+    fn test_artifact_from_digest_bytes() {
+        let raw_bytes = vec![5u8; 32];
+        let digest = DigestBytes::from_bytes(raw_bytes.clone());
+        let artifact = Artifact::from(&digest);
+        assert!(!artifact.has_bytes());
+        assert_eq!(artifact.bytes(), None);
+        assert_eq!(
+            artifact.pre_computed_digest(),
+            Some(raw_bytes.as_slice())
         );
     }
 }

--- a/crates/sigstore-types/src/bundle.rs
+++ b/crates/sigstore-types/src/bundle.rs
@@ -7,8 +7,8 @@
 use crate::checkpoint::Checkpoint;
 use crate::dsse::DsseEnvelope;
 use crate::encoding::{
-    string_i64, CanonicalizedBody, DerCertificate, LogIndex, LogKeyId, Sha256Hash, SignatureBytes,
-    SignedTimestamp, TimestampToken,
+    string_i64, CanonicalizedBody, DerCertificate, DigestBytes, LogIndex, LogKeyId, Sha256Hash,
+    SignatureBytes, SignedTimestamp, TimestampToken,
 };
 use crate::error::{Error, Result};
 use crate::hash::HashAlgorithm;
@@ -171,7 +171,7 @@ pub struct MessageDigest {
     /// Hash algorithm
     pub algorithm: HashAlgorithm,
     /// Digest bytes
-    pub digest: Sha256Hash,
+    pub digest: DigestBytes,
 }
 
 /// Verification material containing certificate/key and log entries

--- a/crates/sigstore-types/src/encoding.rs
+++ b/crates/sigstore-types/src/encoding.rs
@@ -851,6 +851,100 @@ impl<'de> serde::Deserialize<'de> for DigestBytes {
     }
 }
 
+impl TryFrom<DigestBytes> for Sha256Hash {
+    type Error = Error;
+
+    fn try_from(digest: DigestBytes) -> std::result::Result<Self, Self::Error> {
+        Self::try_from_slice(&digest.0)
+    }
+}
+
+impl TryFrom<&DigestBytes> for Sha256Hash {
+    type Error = Error;
+
+    fn try_from(digest: &DigestBytes) -> std::result::Result<Self, Self::Error> {
+        Self::try_from_slice(&digest.0)
+    }
+}
+
+impl From<Sha256Hash> for [u8; 32] {
+    fn from(hash: Sha256Hash) -> Self {
+        hash.0
+    }
+}
+
+impl PartialEq<DigestBytes> for Sha256Hash {
+    fn eq(&self, other: &DigestBytes) -> bool {
+        self.as_slice() == other.as_bytes()
+    }
+}
+
+impl PartialEq<Sha256Hash> for DigestBytes {
+    fn eq(&self, other: &Sha256Hash) -> bool {
+        self.as_bytes() == other.as_slice()
+    }
+}
+
+impl PartialEq<[u8; 32]> for Sha256Hash {
+    fn eq(&self, other: &[u8; 32]) -> bool {
+        &self.0 == other
+    }
+}
+
+impl PartialEq<Sha256Hash> for [u8; 32] {
+    fn eq(&self, other: &Sha256Hash) -> bool {
+        self == &other.0
+    }
+}
+
+impl<'a> PartialEq<&'a [u8]> for Sha256Hash {
+    fn eq(&self, other: &&'a [u8]) -> bool {
+        self.as_slice() == *other
+    }
+}
+
+impl<'a> PartialEq<Sha256Hash> for &'a [u8] {
+    fn eq(&self, other: &Sha256Hash) -> bool {
+        *self == other.as_slice()
+    }
+}
+
+impl PartialEq<Vec<u8>> for Sha256Hash {
+    fn eq(&self, other: &Vec<u8>) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+impl PartialEq<Sha256Hash> for Vec<u8> {
+    fn eq(&self, other: &Sha256Hash) -> bool {
+        self.as_slice() == other.as_slice()
+    }
+}
+
+impl<'a> PartialEq<&'a [u8]> for DigestBytes {
+    fn eq(&self, other: &&'a [u8]) -> bool {
+        self.as_bytes() == *other
+    }
+}
+
+impl<'a> PartialEq<DigestBytes> for &'a [u8] {
+    fn eq(&self, other: &DigestBytes) -> bool {
+        *self == other.as_bytes()
+    }
+}
+
+impl PartialEq<Vec<u8>> for DigestBytes {
+    fn eq(&self, other: &Vec<u8>) -> bool {
+        self.as_bytes() == other.as_slice()
+    }
+}
+
+impl PartialEq<DigestBytes> for Vec<u8> {
+    fn eq(&self, other: &DigestBytes) -> bool {
+        self.as_slice() == other.as_bytes()
+    }
+}
+
 // ============================================================================
 // Hex-Encoded Log ID (for Rekor V1 API compatibility)
 // ============================================================================
@@ -1073,5 +1167,50 @@ mod tests {
         // Round-trip
         let key2 = DerPublicKey::from_pem(&pem).unwrap();
         assert_eq!(key, key2);
+    }
+
+    #[test]
+    fn test_digest_interoperability() {
+        let raw_bytes = [5u8; 32];
+        let sha_hash = Sha256Hash::from_bytes(raw_bytes);
+        let digest_bytes = DigestBytes::from_bytes(raw_bytes.to_vec());
+
+        // From/TryFrom conversions
+        let converted_digest: DigestBytes = sha_hash.into();
+        assert_eq!(converted_digest, digest_bytes);
+
+        let converted_sha1: Sha256Hash = digest_bytes.clone().try_into().unwrap();
+        assert_eq!(converted_sha1, sha_hash);
+
+        let converted_sha2: Sha256Hash = (&digest_bytes).try_into().unwrap();
+        assert_eq!(converted_sha2, sha_hash);
+
+        let array: [u8; 32] = sha_hash.into();
+        assert_eq!(array, raw_bytes);
+
+        // Invalid length TryFrom
+        let bad_digest = DigestBytes::from_bytes(vec![1u8; 16]);
+        let bad_sha_result = Sha256Hash::try_from(bad_digest);
+        assert!(bad_sha_result.is_err());
+
+        // PartialEq comparisons
+        assert_eq!(sha_hash, digest_bytes);
+        assert_eq!(digest_bytes, sha_hash);
+
+        assert_eq!(sha_hash, raw_bytes);
+        assert_eq!(raw_bytes, sha_hash);
+
+        assert_eq!(sha_hash, raw_bytes.as_slice());
+        assert_eq!(raw_bytes.as_slice(), sha_hash);
+
+        let vec_bytes = raw_bytes.to_vec();
+        assert_eq!(sha_hash, vec_bytes);
+        assert_eq!(vec_bytes, sha_hash);
+
+        assert_eq!(digest_bytes, raw_bytes.as_slice());
+        assert_eq!(raw_bytes.as_slice(), digest_bytes);
+
+        assert_eq!(digest_bytes, vec_bytes);
+        assert_eq!(vec_bytes, digest_bytes);
     }
 }

--- a/crates/sigstore-types/src/encoding.rs
+++ b/crates/sigstore-types/src/encoding.rs
@@ -903,7 +903,7 @@ impl<'a> PartialEq<&'a [u8]> for Sha256Hash {
     }
 }
 
-impl<'a> PartialEq<Sha256Hash> for &'a [u8] {
+impl PartialEq<Sha256Hash> for &[u8] {
     fn eq(&self, other: &Sha256Hash) -> bool {
         *self == other.as_slice()
     }
@@ -927,7 +927,7 @@ impl<'a> PartialEq<&'a [u8]> for DigestBytes {
     }
 }
 
-impl<'a> PartialEq<DigestBytes> for &'a [u8] {
+impl PartialEq<DigestBytes> for &[u8] {
     fn eq(&self, other: &DigestBytes) -> bool {
         *self == other.as_bytes()
     }

--- a/crates/sigstore-types/src/encoding.rs
+++ b/crates/sigstore-types/src/encoding.rs
@@ -782,6 +782,76 @@ impl<'de> serde::Deserialize<'de> for Sha256Hash {
 }
 
 // ============================================================================
+// Arbitrary Digest Type (Flexible Size)
+// ============================================================================
+
+/// Arbitrary length hash digest
+///
+/// Flexible-size hash. Serializes as base64, deserializes from either hex or base64.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct DigestBytes(Vec<u8>);
+
+impl DigestBytes {
+    pub fn from_bytes(bytes: Vec<u8>) -> Self {
+        DigestBytes(bytes)
+    }
+
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl AsRef<[u8]> for DigestBytes {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl From<Sha256Hash> for DigestBytes {
+    fn from(hash: Sha256Hash) -> Self {
+        DigestBytes(hash.as_bytes().to_vec())
+    }
+}
+
+impl From<&Sha256Hash> for DigestBytes {
+    fn from(hash: &Sha256Hash) -> Self {
+        DigestBytes(hash.as_bytes().to_vec())
+    }
+}
+
+impl From<&[u8]> for DigestBytes {
+    fn from(bytes: &[u8]) -> Self {
+        DigestBytes(bytes.to_vec())
+    }
+}
+
+impl serde::Serialize for DigestBytes {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(&base64::engine::general_purpose::STANDARD.encode(&self.0))
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for DigestBytes {
+    fn deserialize<D>(deserializer: D) -> std::result::Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        if s.len() % 2 == 0 && s.chars().all(|c| c.is_ascii_hexdigit()) {
+            let bytes = hex::decode(&s).map_err(serde::de::Error::custom)?;
+            return Ok(DigestBytes(bytes));
+        }
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(&s)
+            .map_err(serde::de::Error::custom)?;
+        Ok(DigestBytes(bytes))
+    }
+}
+
+// ============================================================================
 // Hex-Encoded Log ID (for Rekor V1 API compatibility)
 // ============================================================================
 

--- a/crates/sigstore-types/src/lib.rs
+++ b/crates/sigstore-types/src/lib.rs
@@ -22,8 +22,8 @@ pub use checkpoint::{Checkpoint, CheckpointSignature};
 pub use dsse::{pae, DsseEnvelope, DsseSignature};
 pub use encoding::{
     base64_bytes, base64_bytes_option, hex_bytes, string_i64, CanonicalizedBody, DerCertificate,
-    DerPublicKey, DigestBytes, EntryUuid, HexHash, HexLogId, KeyHint, KeyId, LogIndex, LogKeyId, PayloadBytes,
-    PemContent, Sha256Hash, SignatureBytes, SignedTimestamp, TimestampToken,
+    DerPublicKey, DigestBytes, EntryUuid, HexHash, HexLogId, KeyHint, KeyId, LogIndex, LogKeyId,
+    PayloadBytes, PemContent, Sha256Hash, SignatureBytes, SignedTimestamp, TimestampToken,
 };
 pub use error::{Error, Result};
 pub use hash::HashAlgorithm;

--- a/crates/sigstore-types/src/lib.rs
+++ b/crates/sigstore-types/src/lib.rs
@@ -22,7 +22,7 @@ pub use checkpoint::{Checkpoint, CheckpointSignature};
 pub use dsse::{pae, DsseEnvelope, DsseSignature};
 pub use encoding::{
     base64_bytes, base64_bytes_option, hex_bytes, string_i64, CanonicalizedBody, DerCertificate,
-    DerPublicKey, EntryUuid, HexHash, HexLogId, KeyHint, KeyId, LogIndex, LogKeyId, PayloadBytes,
+    DerPublicKey, DigestBytes, EntryUuid, HexHash, HexLogId, KeyHint, KeyId, LogIndex, LogKeyId, PayloadBytes,
     PemContent, Sha256Hash, SignatureBytes, SignedTimestamp, TimestampToken,
 };
 pub use error::{Error, Result};

--- a/crates/sigstore-verify/src/verify.rs
+++ b/crates/sigstore-verify/src/verify.rs
@@ -8,7 +8,7 @@ use sigstore_bundle::ValidationOptions;
 use sigstore_crypto::parse_certificate_info;
 use sigstore_trust_root::TrustedRoot;
 
-use sigstore_types::{Artifact, Bundle, Sha256Hash, SignatureContent, Statement};
+use sigstore_types::{Artifact, Bundle, SignatureContent, Statement};
 
 /// Default clock skew tolerance in seconds (60 seconds = 1 minute)
 pub const DEFAULT_CLOCK_SKEW_SECONDS: i64 = 60;
@@ -377,8 +377,14 @@ impl Verifier {
             if envelope.payload_type == "application/vnd.in-toto+json" {
                 let payload_bytes = envelope.payload.as_bytes();
 
-                let artifact_hash = compute_artifact_digest(&artifact);
-                let artifact_hash_hex = artifact_hash.to_hex();
+                // Note: only SHA-256 used for attestation subjects here
+                let artifact_hash = compute_artifact_digest_algo(
+                    &artifact,
+                    sigstore_types::HashAlgorithm::Sha2256,
+                )?;
+                let artifact_hash_hex = sigstore_types::Sha256Hash::try_from_slice(&artifact_hash)
+                    .map_err(|_| Error::Verification("invalid SHA-256 hash length".to_string()))?
+                    .to_hex();
 
                 let payload_str = std::str::from_utf8(payload_bytes).map_err(|e| {
                     Error::Verification(format!("payload is not valid UTF-8: {}", e))
@@ -399,10 +405,10 @@ impl Verifier {
         // For MessageSignature bundles, verify the messageDigest matches the artifact
         if let SignatureContent::MessageSignature(msg_sig) = &bundle.content {
             if let Some(ref digest) = msg_sig.message_digest {
-                let artifact_hash = compute_artifact_digest(&artifact);
+                let artifact_hash = compute_artifact_digest_algo(&artifact, digest.algorithm)?;
 
                 // Compare the digest in the bundle with the computed artifact hash
-                if digest.digest.as_bytes() != artifact_hash.as_bytes() {
+                if digest.digest.as_bytes() != artifact_hash.as_slice() {
                     return Err(Error::Verification(
                         "message digest in bundle does not match artifact hash".to_string(),
                     ));
@@ -423,12 +429,51 @@ impl Verifier {
     }
 }
 
-/// Compute the SHA-256 digest from an artifact
-fn compute_artifact_digest(artifact: &Artifact<'_>) -> Sha256Hash {
+use sigstore_types::HashAlgorithm;
+fn compute_artifact_digest_algo(artifact: &Artifact<'_>, algo: HashAlgorithm) -> Result<Vec<u8>> {
     match artifact {
-        Artifact::Bytes(bytes) => sigstore_crypto::sha256(bytes),
-        Artifact::Digest(hash) => *hash,
+        Artifact::Bytes(bytes) => match algo {
+            HashAlgorithm::Sha2256 => Ok(sigstore_crypto::sha256(bytes).as_bytes().to_vec()),
+            HashAlgorithm::Sha2384 => Ok(sigstore_crypto::sha384(bytes)),
+            HashAlgorithm::Sha2512 => Ok(sigstore_crypto::sha512(bytes)),
+        },
+        Artifact::Digest(hash) => {
+            let expected_len = algo.digest_size();
+            if hash.len() != expected_len {
+                return Err(Error::Verification(format!(
+                    "expected digest length {} for {:?}, got {}",
+                    expected_len,
+                    algo,
+                    hash.len()
+                )));
+            }
+            Ok(hash.to_vec())
+        }
     }
+}
+
+use sigstore_crypto::SigningScheme;
+fn compute_artifact_digest_for_scheme(
+    artifact: &Artifact<'_>,
+    scheme: SigningScheme,
+) -> Result<Vec<u8>> {
+    let algo = match scheme {
+        SigningScheme::EcdsaP256Sha256
+        | SigningScheme::RsaPssSha256
+        | SigningScheme::RsaPkcs1Sha256 => HashAlgorithm::Sha2256,
+        SigningScheme::EcdsaP256Sha384
+        | SigningScheme::EcdsaP384Sha384
+        | SigningScheme::RsaPssSha384
+        | SigningScheme::RsaPkcs1Sha384 => HashAlgorithm::Sha2384,
+        SigningScheme::RsaPssSha512 | SigningScheme::RsaPkcs1Sha512 => HashAlgorithm::Sha2512,
+        _ => {
+            return Err(Error::Verification(format!(
+                "Unsupported scheme for prehashed verification: {:?}",
+                scheme
+            )))
+        }
+    };
+    compute_artifact_digest_algo(artifact, algo)
 }
 
 /// Convenience function to verify an artifact against a bundle
@@ -438,7 +483,26 @@ fn compute_artifact_digest(artifact: &Artifact<'_>) -> Sha256Hash {
 ///
 /// The artifact can be provided as raw bytes or as a pre-computed SHA-256 digest:
 /// - `verify(artifact_bytes, ...)` - pass raw bytes
-/// - `verify(Sha256Hash::from_hex("...")?, ...)` - pass pre-computed digest
+/// - `verify(digest, ...)` - pass pre-computed digest
+///
+/// # Example
+///
+/// ```no_run
+/// use sigstore_verify::verify;
+/// use sigstore_trust_root::{TrustedRoot, SIGSTORE_PRODUCTION_TRUSTED_ROOT};
+/// use sigstore_types::{Bundle, Sha256Hash};
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let trusted_root = TrustedRoot::from_json(SIGSTORE_PRODUCTION_TRUSTED_ROOT)?;
+/// let bundle_json = std::fs::read_to_string("artifact.sigstore.json")?;
+/// let bundle = Bundle::from_json(&bundle_json)?;
+/// let artifact = std::fs::read("artifact.txt")?;
+///
+/// let result = verify(&artifact, &bundle, &sigstore_verify::VerificationPolicy::default(), &trusted_root)?;
+/// assert!(result.success);
+/// # Ok(())
+/// # }
+/// ```
 pub fn verify<'a>(
     artifact: impl Into<Artifact<'a>>,
     bundle: &Bundle,
@@ -533,8 +597,8 @@ pub fn verify_with_key<'a>(
         SignatureContent::MessageSignature(msg_sig) => {
             // Verify message digest matches artifact
             if let Some(ref digest) = msg_sig.message_digest {
-                let artifact_hash = compute_artifact_digest(&artifact);
-                if digest.digest.as_bytes() != artifact_hash.as_bytes() {
+                let artifact_hash = compute_artifact_digest_algo(&artifact, digest.algorithm)?;
+                if digest.digest.as_bytes() != artifact_hash.as_slice() {
                     return Err(Error::Verification(
                         "message digest in bundle does not match artifact hash".to_string(),
                     ));
@@ -542,10 +606,9 @@ pub fn verify_with_key<'a>(
             }
 
             // Verify signature over the artifact
-            let artifact_hash = compute_artifact_digest(&artifact);
-
             // Use prehashed verification if supported
-            if signing_scheme.uses_sha256() && signing_scheme.supports_prehashed() {
+            if signing_scheme.supports_prehashed() {
+                let artifact_hash = compute_artifact_digest_for_scheme(&artifact, signing_scheme)?;
                 sigstore_crypto::verify_signature_prehashed(
                     public_key,
                     &artifact_hash,
@@ -601,8 +664,15 @@ pub fn verify_with_key<'a>(
 
             // Verify artifact hash matches for in-toto statements
             if envelope.payload_type == "application/vnd.in-toto+json" {
-                let artifact_hash = compute_artifact_digest(&artifact);
-                let artifact_hash_hex = artifact_hash.to_hex();
+                // Note: In-toto specification supports multiple hash algorithms (e.g., sha512),
+                // but Sigstore currently mandates/defaults to SHA-256 for attestation subjects.
+                let artifact_hash = compute_artifact_digest_algo(
+                    &artifact,
+                    sigstore_types::HashAlgorithm::Sha2256,
+                )?;
+                let artifact_hash_hex = sigstore_types::Sha256Hash::try_from_slice(&artifact_hash)
+                    .map_err(|_| Error::Verification("invalid SHA-256 hash length".to_string()))?
+                    .to_hex();
 
                 let payload_str = std::str::from_utf8(&payload_bytes).map_err(|e| {
                     Error::Verification(format!("payload is not valid UTF-8: {}", e))

--- a/crates/sigstore-verify/src/verify.rs
+++ b/crates/sigstore-verify/src/verify.rs
@@ -358,7 +358,7 @@ impl Verifier {
                     &cert_info.public_key,
                     &pae,
                     &sig.sig,
-                    cert_info.signing_scheme,
+                    cert_info.key_algorithm.default_signing_scheme(),
                 )
                 .is_ok()
                 {
@@ -459,6 +459,7 @@ fn compute_artifact_digest_for_scheme(
 ) -> Result<Vec<u8>> {
     let algo = match scheme {
         SigningScheme::EcdsaP256Sha256
+        | SigningScheme::EcdsaP384Sha256
         | SigningScheme::RsaPssSha256
         | SigningScheme::RsaPkcs1Sha256 => HashAlgorithm::Sha2256,
         SigningScheme::EcdsaP256Sha384

--- a/crates/sigstore-verify/src/verify.rs
+++ b/crates/sigstore-verify/src/verify.rs
@@ -408,7 +408,7 @@ impl Verifier {
                 let artifact_hash = compute_artifact_digest_algo(&artifact, digest.algorithm)?;
 
                 // Compare the digest in the bundle with the computed artifact hash
-                if digest.digest.as_bytes() != artifact_hash.as_slice() {
+                if digest.digest != artifact_hash {
                     return Err(Error::Verification(
                         "message digest in bundle does not match artifact hash".to_string(),
                     ));
@@ -599,7 +599,7 @@ pub fn verify_with_key<'a>(
             // Verify message digest matches artifact
             if let Some(ref digest) = msg_sig.message_digest {
                 let artifact_hash = compute_artifact_digest_algo(&artifact, digest.algorithm)?;
-                if digest.digest.as_bytes() != artifact_hash.as_slice() {
+                if digest.digest != artifact_hash {
                     return Err(Error::Verification(
                         "message digest in bundle does not match artifact hash".to_string(),
                     ));

--- a/crates/sigstore-verify/src/verify_impl/hashedrekord.rs
+++ b/crates/sigstore-verify/src/verify_impl/hashedrekord.rs
@@ -29,7 +29,7 @@ pub(crate) fn verify_hashedrekord_entry(
 
     // Compute hash from artifact (bytes or pre-computed digest) or DSSE envelope
     let hash = match &bundle.content {
-        SignatureContent::MessageSignature(_) => compute_artifact_digest(artifact),
+        SignatureContent::MessageSignature(_) => compute_artifact_digest(artifact)?,
         SignatureContent::DsseEnvelope(envelope) => sigstore_crypto::sha256(&envelope.pae()),
     };
 
@@ -67,20 +67,20 @@ pub(crate) fn verify_hashedrekord_entry(
     validate_integrated_time(entry, bundle)?;
 
     // Perform cryptographic signature verification
-    // This verifies that the signature in the Rekor entry was created by the
-    // certificate's private key over the artifact hash.
-    // Uses verify_signature_prehashed with Digest::import_less_safe for proper
-    // prehashed verification (avoiding double-hashing).
     verify_signature_cryptographically(entry, &body, bundle, artifact)?;
 
     Ok(())
 }
 
-/// Compute the SHA-256 digest from an artifact
-fn compute_artifact_digest(artifact: &Artifact<'_>) -> Sha256Hash {
+/// Compute the SHA-256 digest from an artifact for Rekor inclusion proof
+fn compute_artifact_digest(artifact: &Artifact<'_>) -> Result<Sha256Hash> {
     match artifact {
-        Artifact::Bytes(bytes) => sigstore_crypto::sha256(bytes),
-        Artifact::Digest(hash) => *hash,
+        Artifact::Bytes(bytes) => Ok(sigstore_crypto::sha256(bytes)),
+        Artifact::Digest(hash) => Sha256Hash::try_from_slice(hash).map_err(|_| {
+            Error::Verification(
+                "Rekor entry verification requires a 32-byte SHA-256 digest".to_string(),
+            )
+        }),
     }
 }
 
@@ -214,11 +214,9 @@ fn validate_signature_match(
 /// Verification strategy:
 /// - If we have the artifact bytes: verify signature over the artifact using `verify_signature`
 /// - If we only have the digest:
-///   - For SHA-256 schemes (P-256/SHA-256, RSA-PSS-SHA-256, etc.): Use prehashed verification
-///     since Rekor stores SHA-256 hashes which match the signature's hash algorithm
-///   - For SHA-384/512 schemes (P-384/SHA-384, etc.): Skip verification because Rekor's
-///     SHA-256 hash doesn't match the signature's hash algorithm
-///   - For Ed25519: Skip verification (doesn't support prehashed mode)
+///   - Verify using `verify_signature_prehashed` which will dynamically map to the correct digest
+///     algorithm based on the signing scheme.
+///   - If the scheme does not support prehashed mode (like Ed25519), we fail closed and return an error.
 fn verify_signature_cryptographically(
     _entry: &TransparencyLogEntry,
     body: &RekorEntryBody,
@@ -278,9 +276,7 @@ fn verify_signature_cryptographically(
                 }
                 Artifact::Digest(hash) => {
                     // We only have the digest - use prehashed verification if supported
-                    if cert_info.signing_scheme.uses_sha256()
-                        && cert_info.signing_scheme.supports_prehashed()
-                    {
+                    if cert_info.signing_scheme.supports_prehashed() {
                         tracing::debug!(
                             "Using prehashed verification for {} with pre-computed digest",
                             cert_info.signing_scheme.name()
@@ -299,13 +295,11 @@ fn verify_signature_cryptographically(
                             ))
                         })?;
                     } else {
-                        // Scheme doesn't use SHA-256 or doesn't support prehashed verification.
-                        // We can't verify without the original artifact.
-                        tracing::debug!(
-                            "Skipping cryptographic signature verification for {} with digest-only - \
-                             scheme uses different hash algorithm or doesn't support prehashed",
+                        // Scheme doesn't support prehashed verification: fail closed
+                        return Err(Error::Verification(format!(
+                            "cannot verify signature with digest-only - scheme {} does not support prehashed mode",
                             cert_info.signing_scheme.name()
-                        );
+                        )));
                     }
                 }
             }

--- a/crates/sigstore-verify/src/verify_impl/hashedrekord.rs
+++ b/crates/sigstore-verify/src/verify_impl/hashedrekord.rs
@@ -258,6 +258,20 @@ fn verify_signature_cryptographically(
             // Parse certificate to extract public key and algorithm
             let cert_info = sigstore_crypto::x509::parse_certificate_info(cert_der)?;
 
+            // use digest algorithm from message digest, or the default for key algorithm
+            let scheme = match &bundle.content {
+                SignatureContent::MessageSignature(msg_sig) => {
+                    if let Some(ref digest) = msg_sig.message_digest {
+                        cert_info
+                            .key_algorithm
+                            .resolve_signing_scheme(digest.algorithm)?
+                    } else {
+                        cert_info.key_algorithm.default_signing_scheme()
+                    }
+                }
+                _ => cert_info.key_algorithm.default_signing_scheme(),
+            };
+
             match artifact {
                 Artifact::Bytes(bytes) => {
                     // We have the artifact bytes - verify signature over them
@@ -265,7 +279,7 @@ fn verify_signature_cryptographically(
                         &cert_info.public_key,
                         bytes,
                         &signature_bytes,
-                        cert_info.signing_scheme,
+                        scheme,
                     )
                     .map_err(|e| {
                         Error::Verification(format!(
@@ -276,17 +290,17 @@ fn verify_signature_cryptographically(
                 }
                 Artifact::Digest(hash) => {
                     // We only have the digest - use prehashed verification if supported
-                    if cert_info.signing_scheme.supports_prehashed() {
+                    if scheme.supports_prehashed() {
                         tracing::debug!(
                             "Using prehashed verification for {} with pre-computed digest",
-                            cert_info.signing_scheme.name()
+                            scheme.name()
                         );
 
                         sigstore_crypto::verification::verify_signature_prehashed(
                             &cert_info.public_key,
                             hash,
                             &signature_bytes,
-                            cert_info.signing_scheme,
+                            scheme,
                         )
                         .map_err(|e| {
                             Error::Verification(format!(
@@ -298,7 +312,7 @@ fn verify_signature_cryptographically(
                         // Scheme doesn't support prehashed verification: fail closed
                         return Err(Error::Verification(format!(
                             "cannot verify signature with digest-only - scheme {} does not support prehashed mode",
-                            cert_info.signing_scheme.name()
+                            scheme.name()
                         )));
                     }
                 }

--- a/crates/sigstore-verify/tests/verification_tests.rs
+++ b/crates/sigstore-verify/tests/verification_tests.rs
@@ -30,7 +30,7 @@ fn extract_artifact_digest(bundle: &Bundle) -> Option<Sha256Hash> {
         sigstore_verify::types::SignatureContent::MessageSignature(msg_sig) => msg_sig
             .message_digest
             .as_ref()
-            .and_then(|d| Sha256Hash::try_from_slice(d.digest.as_bytes()).ok()),
+            .and_then(|d| Sha256Hash::try_from(&d.digest).ok()),
     }
 }
 


### PR DESCRIPTION
This ended up becoming multiple changes:

* Avoid double-hashing digests via verify_inner for non-ECDSA schemes
* Do not fail-open when unsupported signing schemes are seen
* Support multiple digest types via a "DigestBytes" and generic slices: in practice this means sha256/sha384/sha512. The hash algorithm is chosen based on the signing algorithm, except...
* Introduces KeyAlgorithm enum in to represent public key types extracted from the certificate without guessing the hash algorithm: in some cases we can get the actual hash algorithm from the bundle
