### PR TITLE
Merkle fixes

### DIFF
--- a/crates/sigstore-merkle/src/proof.rs
+++ b/crates/sigstore-merkle/src/proof.rs
@@ -241,7 +241,7 @@ fn expected_inclusion_proof_length(leaf_index: u64, tree_size: u64) -> usize {
         }
         // Move to parent level
         index /= 2;
-        size = (size + 1) / 2;
+        size = (size / 2) + (size % 2);
     }
 
     count

--- a/crates/sigstore-merkle/src/proof.rs
+++ b/crates/sigstore-merkle/src/proof.rs
@@ -4,7 +4,7 @@
 //! The algorithm follows the reference implementations from sigstore-python and sigstore-go.
 
 use crate::error::{Error, Result};
-use crate::tree::{bit_length, hash_children};
+use crate::tree::hash_children;
 use sigstore_types::Sha256Hash;
 
 /// Verify an inclusion proof for a leaf in a Merkle tree
@@ -216,7 +216,8 @@ fn decompose_inclusion_proof(index: u64, tree_size: u64) -> Result<(usize, usize
 
 /// Calculate the inner proof size for a given index and tree size
 fn inner_proof_size(index: u64, tree_size: u64) -> usize {
-    bit_length(index ^ (tree_size - 1)) as usize
+    let diff = index ^ (tree_size - 1);
+    64 - diff.leading_zeros() as usize
 }
 
 /// Calculate the expected inclusion proof length for a given leaf index and tree size

--- a/crates/sigstore-merkle/src/tree.rs
+++ b/crates/sigstore-merkle/src/tree.rs
@@ -34,24 +34,6 @@ pub fn hash_children(left: &Sha256Hash, right: &Sha256Hash) -> Sha256Hash {
     hasher.finalize()
 }
 
-/// Calculate the number of trailing zeros in a number (LSB)
-pub fn trailing_zeros(n: u64) -> u32 {
-    if n == 0 {
-        64
-    } else {
-        n.trailing_zeros()
-    }
-}
-
-/// Calculate the position of the most significant bit
-pub fn bit_length(n: u64) -> u32 {
-    if n == 0 {
-        0
-    } else {
-        64 - n.leading_zeros()
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -80,26 +62,5 @@ mod tests {
         // Verify order matters
         let hash_reversed = hash_children(&right, &left);
         assert_ne!(hash, hash_reversed);
-    }
-
-    #[test]
-    fn test_trailing_zeros() {
-        assert_eq!(trailing_zeros(0), 64);
-        assert_eq!(trailing_zeros(1), 0);
-        assert_eq!(trailing_zeros(2), 1);
-        assert_eq!(trailing_zeros(4), 2);
-        assert_eq!(trailing_zeros(8), 3);
-        assert_eq!(trailing_zeros(6), 1); // 110 in binary
-    }
-
-    #[test]
-    fn test_bit_length() {
-        assert_eq!(bit_length(0), 0);
-        assert_eq!(bit_length(1), 1);
-        assert_eq!(bit_length(2), 2);
-        assert_eq!(bit_length(3), 2);
-        assert_eq!(bit_length(4), 3);
-        assert_eq!(bit_length(255), 8);
-        assert_eq!(bit_length(256), 9);
     }
 }


### PR DESCRIPTION
Two separate changes that I can split if requested:
* Fix overflow in max tree size case
* Remove helper methods that do basically nothing (stdlib `trailing_zeros()` and `leading_zeros()` already handle the case of 0 as input correctly, no need to special case this locally)