### PR TITLE
sign: Require complete SigningConfig from tuf

### DIFF
--- a/crates/sigstore-conformance/src/main.rs
+++ b/crates/sigstore-conformance/src/main.rs
@@ -119,7 +119,7 @@ async fn sign_bundle(args: &[String]) -> Result<(), Box<dyn std::error::Error>> 
 
     let signing_config = if let Some(config_path) = &_signing_config {
         let tuf_config = TufSigningConfig::from_file(config_path)?;
-        SignerSigningConfig::from_tuf_config(&tuf_config)
+        SignerSigningConfig::from_tuf_config(&tuf_config)?
     } else if staging {
         SignerSigningConfig::staging()
     } else {

--- a/crates/sigstore-sign/examples/sign_attestation.rs
+++ b/crates/sigstore-sign/examples/sign_attestation.rs
@@ -149,7 +149,8 @@ async fn main() {
             .await
             .expect("Failed to fetch production config via TUF")
     };
-    let config = SigningConfig::from_tuf_config(&tuf_config);
+    let config = SigningConfig::from_tuf_config(&tuf_config)
+        .expect("Missing required endpoints in TUF config");
 
     println!("  Fulcio URL: {}", config.fulcio_url);
     println!("  Rekor URL: {}", config.rekor_url);

--- a/crates/sigstore-sign/examples/sign_blob.rs
+++ b/crates/sigstore-sign/examples/sign_blob.rs
@@ -129,7 +129,8 @@ async fn main() {
             .await
             .expect("Failed to fetch production config via TUF")
     };
-    let base_config = SigningConfig::from_tuf_config(&tuf_config);
+    let base_config = SigningConfig::from_tuf_config(&tuf_config)
+        .expect("Missing required endpoints in TUF config");
 
     let config = if use_v2 {
         base_config.with_rekor_version(RekorApiVersion::V2)

--- a/crates/sigstore-sign/src/error.rs
+++ b/crates/sigstore-sign/src/error.rs
@@ -9,6 +9,10 @@ pub enum Error {
     #[error("Signing error: {0}")]
     Signing(String),
 
+    /// Config error
+    #[error("Config error: {0}")]
+    Config(String),
+
     /// Types error
     #[error("Types error: {0}")]
     Types(#[from] sigstore_types::Error),

--- a/crates/sigstore-sign/src/sign.rs
+++ b/crates/sigstore-sign/src/sign.rs
@@ -57,8 +57,9 @@ impl SigningConfig {
     pub fn production() -> Self {
         Self::from_tuf_config(
             &TufSigningConfig::from_json(SIGSTORE_PRODUCTION_SIGNING_CONFIG)
-                .expect("embedded config is valid"),
+                .expect("Failed to parse embedded production config"),
         )
+        .expect("Failed to find required endpoints in embedded production config")
     }
 
     /// Create configuration for Sigstore staging instance
@@ -68,8 +69,9 @@ impl SigningConfig {
     pub fn staging() -> Self {
         Self::from_tuf_config(
             &TufSigningConfig::from_json(SIGSTORE_STAGING_SIGNING_CONFIG)
-                .expect("embedded config is valid"),
+                .expect("Failed to parse embedded staging config"),
         )
+        .expect("Failed to find required endpoints in embedded staging config")
     }
 
     /// Create configuration from a TUF signing config
@@ -80,7 +82,7 @@ impl SigningConfig {
     /// # Arguments
     ///
     /// * `tuf_config` - The signing config from TUF
-    pub fn from_tuf_config(tuf_config: &TufSigningConfig) -> Self {
+    pub fn from_tuf_config(tuf_config: &TufSigningConfig) -> Result<Self> {
         Self::from_tuf_config_with_rekor_version(tuf_config, None)
     }
 
@@ -93,11 +95,11 @@ impl SigningConfig {
     pub fn from_tuf_config_with_rekor_version(
         tuf_config: &TufSigningConfig,
         force_rekor_version: Option<u32>,
-    ) -> Self {
+    ) -> Result<Self> {
         let fulcio_url = tuf_config
             .get_fulcio_url()
             .map(|e| e.url.clone())
-            .unwrap_or_else(|| "https://fulcio.sigstore.dev".to_string());
+            .ok_or_else(|| Error::Config("Missing Fulcio URL in TUF config".to_string()))?;
 
         let (rekor_url, rekor_api_version) =
             if let Some(rekor) = tuf_config.get_rekor_url(force_rekor_version) {
@@ -108,23 +110,20 @@ impl SigningConfig {
                 };
                 (rekor.url.clone(), version)
             } else {
-                (
-                    "https://rekor.sigstore.dev".to_string(),
-                    RekorApiVersion::V1,
-                )
+                return Err(Error::Config("Missing Rekor URL in TUF config".to_string()));
             };
 
         let tsa_url = tuf_config.get_tsa_url().map(|e| e.url.clone());
         let oidc_url = tuf_config.get_oidc_url().map(|e| e.url.clone());
 
-        Self {
+        Ok(Self {
             fulcio_url,
             rekor_url,
             tsa_url,
             signing_scheme: SigningScheme::EcdsaP256Sha256,
             rekor_api_version,
             oidc_url,
-        }
+        })
     }
 
     /// Set the Rekor API version and automatically update the URL


### PR DESCRIPTION
Let's not use default values if TUF is used and the received SigningConfig is incomplete