### PR TITLE
oidc: Don't advertize unreliable parsing mechanism

### DIFF
--- a/crates/sigstore-oidc/src/token.rs
+++ b/crates/sigstore-oidc/src/token.rs
@@ -111,35 +111,6 @@ impl IdentityToken {
         }
     }
 
-    /// Create from raw token string without parsing
-    pub fn new(token: impl Into<String>) -> Self {
-        let raw = token.into();
-        // Try to parse, fall back to empty claims
-        let claims = Self::parse_claims(&raw).unwrap_or_else(|_| TokenClaims {
-            iss: String::new(),
-            sub: String::new(),
-            aud: Audience::None,
-            exp: 0,
-            iat: 0,
-            email: None,
-            email_verified: None,
-            federated_claims: None,
-        });
-        Self { raw, claims }
-    }
-
-    fn parse_claims(token: &str) -> Result<TokenClaims> {
-        let parts: Vec<&str> = token.split('.').collect();
-        if parts.len() != 3 {
-            return Err(Error::Token("invalid JWT format".to_string()));
-        }
-        let payload = URL_SAFE_NO_PAD
-            .decode(parts[1])
-            .map_err(|e| Error::Token(format!("failed to decode payload: {}", e)))?;
-        serde_json::from_slice(&payload)
-            .map_err(|e| Error::Token(format!("failed to parse claims: {}", e)))
-    }
-
     /// Get the raw JWT string
     pub fn raw(&self) -> &str {
         &self.raw

--- a/crates/sigstore-sign/src/lib.rs
+++ b/crates/sigstore-sign/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 //! let context = SigningContext::production();
-//! let token = IdentityToken::new("your-identity-token".to_string());
+//! let token = IdentityToken::from_jwt("header.payload.signature")?;
 //! let signer = context.signer(token);
 //!
 //! let artifact = b"hello world";

--- a/crates/sigstore-sign/src/sign.rs
+++ b/crates/sigstore-sign/src/sign.rs
@@ -215,7 +215,7 @@ impl Signer {
     ///
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let context = SigningContext::production();
-    /// let token = IdentityToken::new("your-token-here".to_string());
+    /// let token = IdentityToken::from_jwt("header.payload.signature")?;
     /// let signer = context.signer(token);
     /// let artifact = b"hello world";
     /// let bundle = signer.sign(artifact.as_slice()).await?;
@@ -366,7 +366,7 @@ impl Signer {
     ///
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let context = SigningContext::production();
-    /// let token = IdentityToken::new("your-token-here".to_string());
+    /// let token = IdentityToken::from_jwt("header.payload.signature")?;
     /// let signer = context.signer(token);
     ///
     /// // Create attestation with pre-computed digest (no raw bytes needed!)
@@ -611,7 +611,9 @@ mod tests {
     #[tokio::test]
     async fn test_create_dsse_rekor_entry_invalid_signature_count() {
         let context = SigningContext::new();
-        let token = IdentityToken::new("dummy-token".to_string());
+        let dummy_jwt =
+            "eyJhbGciOiJub25lIn0.eyJpc3MiOiJ0ZXN0Iiwic3ViIjoidGVzdCIsImV4cCI6MH0.signature";
+        let token = IdentityToken::from_jwt(dummy_jwt).unwrap();
         let signer = context.signer(token);
 
         let certificate = DerCertificate::new(vec![0x30, 0x00]);


### PR DESCRIPTION
IdentityToken::new() would silently replace the token with default values on failure -- this is fine for tests where it was used... but this method was also used in documentation which will lead to someone using this in prod.

Remove new(), document from_jwt() instead.

Also remove the parsing method as from_jwt() already does the same.

