### PR TITLE
trust-root: enforce valid_for in key accessors, surface parse errors

### DIFF
--- a/crates/sigstore-trust-root/src/trusted_root.rs
+++ b/crates/sigstore-trust-root/src/trusted_root.rs
@@ -171,6 +171,65 @@ pub struct ValidityPeriod {
     pub end: Option<String>,
 }
 
+fn parse_validity_timestamp(value: Option<&str>, field: &str) -> Result<Option<Timestamp>> {
+    value
+        .map(|s| {
+            s.parse::<Timestamp>().map_err(|e| {
+                Error::TimeParse(format!("invalid validFor.{field} timestamp {s:?}: {e}"))
+            })
+        })
+        .transpose()
+}
+
+impl ValidityPeriod {
+    /// Parsed start of the validity window.
+    ///
+    /// Returns an error if the timestamp is present but malformed.
+    pub fn start(&self) -> Result<Option<Timestamp>> {
+        parse_validity_timestamp(self.start.as_deref(), "start")
+    }
+
+    /// Parsed end of the validity window.
+    ///
+    /// Returns an error if the timestamp is present but malformed.
+    pub fn end(&self) -> Result<Option<Timestamp>> {
+        parse_validity_timestamp(self.end.as_deref(), "end")
+    }
+
+    /// Whether `time` falls within this validity window.
+    ///
+    /// A missing `start` or `end` bound is treated as unbounded on that side.
+    /// Returns an error if a timestamp is present but malformed.
+    pub fn contains(&self, time: Timestamp) -> Result<bool> {
+        let after_start = self.start()?.map_or(true, |s| time >= s);
+        let before_end = self.end()?.map_or(true, |e| time <= e);
+        Ok(after_start && before_end)
+    }
+
+    /// Whether this validity window has started by `time` (i.e. `start` is
+    /// unset or `start <= time`).
+    ///
+    /// Instances that have started — including ones whose window has since
+    /// expired — are still required to verify historical material that was
+    /// produced while they were valid.
+    pub fn has_started_by(&self, time: Timestamp) -> Result<bool> {
+        Ok(self.start()?.map_or(true, |s| time >= s))
+    }
+}
+
+/// Whether an instance with the given `valid_for` may be used as verification
+/// material at `now`.
+///
+/// Instances without a `valid_for` constraint are always usable. Instances
+/// whose window has not started yet are excluded; expired instances are kept
+/// because historical entries/certificates were created while they were valid.
+fn usable_for_verification(valid_for: Option<&ValidityPeriod>, now: Timestamp) -> Result<bool> {
+    match valid_for {
+        None => Ok(true),
+        Some(period) => period.has_started_by(now),
+    }
+}
+
 impl TrustedRoot {
     /// Parse a trusted root from JSON
     pub fn from_json(json: &str) -> Result<Self> {
@@ -185,9 +244,17 @@ impl TrustedRoot {
     }
 
     /// Get all Fulcio certificate authority certificates
+    ///
+    /// Certificate authorities whose `valid_for` window has not started yet
+    /// are excluded. Expired certificate authorities are included because
+    /// they are needed to verify certificates issued while they were valid.
     pub fn fulcio_certs(&self) -> Result<Vec<CertificateDer<'static>>> {
+        let now = Timestamp::now();
         let mut certs = Vec::new();
         for ca in &self.certificate_authorities {
+            if !usable_for_verification(ca.valid_for.as_ref(), now)? {
+                continue;
+            }
             for cert_entry in &ca.cert_chain.certificates {
                 certs.push(CertificateDer::from(cert_entry.raw_bytes.as_bytes()).into_owned());
             }
@@ -196,9 +263,17 @@ impl TrustedRoot {
     }
 
     /// Get all Rekor public keys mapped by key ID
+    ///
+    /// Keys whose `valid_for` window has not started yet are excluded.
+    /// Expired keys are included because they are needed to verify log
+    /// entries that were integrated while the key was valid.
     pub fn rekor_keys(&self) -> Result<HashMap<String, Vec<u8>>> {
+        let now = Timestamp::now();
         let mut keys = HashMap::new();
         for tlog in &self.tlogs {
+            if !usable_for_verification(tlog.public_key.valid_for.as_ref(), now)? {
+                continue;
+            }
             keys.insert(
                 tlog.log_id.key_id.to_string(),
                 tlog.public_key.raw_bytes.as_bytes().to_vec(),
@@ -211,9 +286,17 @@ impl TrustedRoot {
     ///
     /// Returns a vector of (key_hint, public_key) tuples where key_hint is
     /// the first 4 bytes of the keyId from the log_id field.
+    ///
+    /// Keys whose `valid_for` window has not started yet are excluded.
+    /// Expired keys are included because they are needed to verify log
+    /// entries that were integrated while the key was valid.
     pub fn rekor_keys_with_hints(&self) -> Result<Vec<(KeyHint, DerPublicKey)>> {
+        let now = Timestamp::now();
         let mut keys = Vec::new();
         for tlog in &self.tlogs {
+            if !usable_for_verification(tlog.public_key.valid_for.as_ref(), now)? {
+                continue;
+            }
             // Decode the key_id to get the key hint (first 4 bytes)
             let key_id_bytes = tlog.log_id.key_id.decode()?;
 
@@ -231,19 +314,56 @@ impl TrustedRoot {
     }
 
     /// Get a specific Rekor public key by log ID
+    ///
+    /// Keys whose `valid_for` window has not started yet are not returned.
+    /// Expired keys are returned because they are needed to verify log
+    /// entries that were integrated while the key was valid.
     pub fn rekor_key_for_log(&self, log_id: &LogKeyId) -> Result<DerPublicKey> {
+        let now = Timestamp::now();
         for tlog in &self.tlogs {
             if &tlog.log_id.key_id == log_id {
+                if !usable_for_verification(tlog.public_key.valid_for.as_ref(), now)? {
+                    continue;
+                }
                 return Ok(tlog.public_key.raw_bytes.clone());
             }
         }
         Err(Error::KeyNotFound(log_id.to_string()))
     }
 
+    /// Get a specific Rekor public key by log ID, valid at the given time
+    ///
+    /// Unlike [`Self::rekor_key_for_log`] this requires the key's `valid_for`
+    /// window (if present) to fully contain `time`, which is suitable when
+    /// the relevant timestamp of the material being verified is known (e.g.
+    /// a log entry's integrated time).
+    pub fn rekor_key_for_log_at(&self, log_id: &LogKeyId, time: Timestamp) -> Result<DerPublicKey> {
+        for tlog in &self.tlogs {
+            if &tlog.log_id.key_id == log_id {
+                let valid = match &tlog.public_key.valid_for {
+                    None => true,
+                    Some(period) => period.contains(time)?,
+                };
+                if valid {
+                    return Ok(tlog.public_key.raw_bytes.clone());
+                }
+            }
+        }
+        Err(Error::KeyNotFound(log_id.to_string()))
+    }
+
     /// Get all Certificate Transparency log public keys mapped by key ID
+    ///
+    /// Keys whose `valid_for` window has not started yet are excluded.
+    /// Expired keys are included because they are needed to verify SCTs
+    /// issued while the key was valid.
     pub fn ctfe_keys(&self) -> Result<HashMap<LogKeyId, DerPublicKey>> {
+        let now = Timestamp::now();
         let mut keys = HashMap::new();
         for ctlog in &self.ctlogs {
+            if !usable_for_verification(ctlog.public_key.valid_for.as_ref(), now)? {
+                continue;
+            }
             keys.insert(
                 ctlog.log_id.key_id.clone(),
                 ctlog.public_key.raw_bytes.clone(),
@@ -255,9 +375,17 @@ impl TrustedRoot {
     /// Get all Certificate Transparency log public keys with their SHA-256 log IDs
     /// Returns a list of (log_id, public_key) pairs where log_id is the SHA-256 hash
     /// of the public key (used for matching against SCTs)
+    ///
+    /// Keys whose `valid_for` window has not started yet are excluded.
+    /// Expired keys are included because they are needed to verify SCTs
+    /// issued while the key was valid.
     pub fn ctfe_keys_with_ids(&self) -> Result<Vec<(Vec<u8>, DerPublicKey)>> {
+        let now = Timestamp::now();
         let mut result = Vec::new();
         for ctlog in &self.ctlogs {
+            if !usable_for_verification(ctlog.public_key.valid_for.as_ref(), now)? {
+                continue;
+            }
             let key_bytes = ctlog.public_key.raw_bytes.as_bytes();
             // Compute SHA-256 hash of the public key to get the log ID
             let log_id = sigstore_crypto::sha256(key_bytes).as_bytes().to_vec();
@@ -267,28 +395,20 @@ impl TrustedRoot {
     }
 
     /// Get all TSA certificates with their validity periods
+    ///
+    /// Returns an error if a `valid_for` timestamp is present but malformed.
     pub fn tsa_certs_with_validity(&self) -> Result<Vec<TsaCertWithValidity>> {
         let mut result = Vec::new();
 
         for tsa in &self.timestamp_authorities {
+            // Parse validity period, propagating malformed timestamps as errors
+            let (start, end) = match &tsa.valid_for {
+                Some(valid_for) => (valid_for.start()?, valid_for.end()?),
+                None => (None, None),
+            };
+
             for cert_entry in &tsa.cert_chain.certificates {
                 let cert_der = cert_entry.raw_bytes.as_bytes().to_vec();
-
-                // Parse validity period
-                let (start, end) = if let Some(valid_for) = &tsa.valid_for {
-                    let start = valid_for
-                        .start
-                        .as_ref()
-                        .and_then(|s| s.parse::<Timestamp>().ok());
-                    let end = valid_for
-                        .end
-                        .as_ref()
-                        .and_then(|s| s.parse::<Timestamp>().ok());
-                    (start, end)
-                } else {
-                    (None, None)
-                };
-
                 result.push((CertificateDer::from(&cert_der[..]).into_owned(), start, end));
             }
         }
@@ -297,9 +417,17 @@ impl TrustedRoot {
     }
 
     /// Get TSA root certificates (for chain validation)
+    ///
+    /// Timestamp authorities whose `valid_for` window has not started yet are
+    /// excluded. Expired authorities are included because they are needed to
+    /// verify timestamps issued while they were valid.
     pub fn tsa_root_certs(&self) -> Result<Vec<CertificateDer<'static>>> {
+        let now = Timestamp::now();
         let mut roots = Vec::new();
         for tsa in &self.timestamp_authorities {
+            if !usable_for_verification(tsa.valid_for.as_ref(), now)? {
+                continue;
+            }
             // The last certificate in the chain is typically the root
             if let Some(cert_entry) = tsa.cert_chain.certificates.last() {
                 roots.push(CertificateDer::from(cert_entry.raw_bytes.as_bytes()).into_owned());
@@ -309,9 +437,17 @@ impl TrustedRoot {
     }
 
     /// Get TSA intermediate certificates (for chain validation)
+    ///
+    /// Timestamp authorities whose `valid_for` window has not started yet are
+    /// excluded. Expired authorities are included because they are needed to
+    /// verify timestamps issued while they were valid.
     pub fn tsa_intermediate_certs(&self) -> Result<Vec<CertificateDer<'static>>> {
+        let now = Timestamp::now();
         let mut intermediates = Vec::new();
         for tsa in &self.timestamp_authorities {
+            if !usable_for_verification(tsa.valid_for.as_ref(), now)? {
+                continue;
+            }
             // All certificates except the first (leaf) and last (root) are intermediates
             let chain_len = tsa.cert_chain.certificates.len();
             if chain_len > 2 {
@@ -326,9 +462,17 @@ impl TrustedRoot {
 
     /// Get TSA leaf certificates (the first certificate in each chain)
     /// These are the actual TSA signing certificates
+    ///
+    /// Timestamp authorities whose `valid_for` window has not started yet are
+    /// excluded. Expired authorities are included because they are needed to
+    /// verify timestamps issued while they were valid.
     pub fn tsa_leaf_certs(&self) -> Result<Vec<CertificateDer<'static>>> {
+        let now = Timestamp::now();
         let mut leaves = Vec::new();
         for tsa in &self.timestamp_authorities {
+            if !usable_for_verification(tsa.valid_for.as_ref(), now)? {
+                continue;
+            }
             // The first certificate in the chain is the leaf (TSA signing cert)
             if let Some(cert_entry) = tsa.cert_chain.certificates.first() {
                 leaves.push(CertificateDer::from(cert_entry.raw_bytes.as_bytes()).into_owned());
@@ -338,25 +482,23 @@ impl TrustedRoot {
     }
 
     /// Check if a Rekor key ID exists in the trusted root
+    ///
+    /// Note: this is a pure presence check and does not consider `valid_for`.
     pub fn has_rekor_key(&self, key_id: &LogKeyId) -> bool {
         self.tlogs.iter().any(|tlog| &tlog.log_id.key_id == key_id)
     }
 
     /// Get the validity period for a TSA at a given time
+    ///
+    /// Returns an error if a `valid_for` timestamp is present but malformed.
     pub fn tsa_validity_for_time(
         &self,
         timestamp: Timestamp,
     ) -> Result<Option<(Timestamp, Timestamp)>> {
         for tsa in &self.timestamp_authorities {
             if let Some(valid_for) = &tsa.valid_for {
-                let start = valid_for
-                    .start
-                    .as_ref()
-                    .and_then(|s| s.parse::<Timestamp>().ok());
-                let end = valid_for
-                    .end
-                    .as_ref()
-                    .and_then(|s| s.parse::<Timestamp>().ok());
+                let start = valid_for.start()?;
+                let end = valid_for.end()?;
 
                 // Check if timestamp falls within this TSA's validity
                 if let (Some(start_time), Some(end_time)) = (start, end) {
@@ -376,45 +518,35 @@ impl TrustedRoot {
 
     /// Check if a timestamp is within any TSA's validity period from the trust root
     ///
-    /// Returns true if:
+    /// Returns `Ok(true)` if:
     /// - There are no timestamp authorities configured (no TSA verification)
     /// - Any TSA has no `valid_for` field (open-ended validity)
     /// - The timestamp falls within at least one TSA's `valid_for` period
     ///
-    /// Returns false only if there are TSAs with validity constraints and the
-    /// timestamp doesn't fall within any of them.
-    pub fn is_timestamp_within_tsa_validity(&self, timestamp: Timestamp) -> bool {
+    /// Returns `Ok(false)` only if there are TSAs with validity constraints and
+    /// the timestamp doesn't fall within any of them.
+    ///
+    /// Returns an error if a `valid_for` timestamp is present but malformed.
+    pub fn is_timestamp_within_tsa_validity(&self, timestamp: Timestamp) -> Result<bool> {
         // If no TSAs are configured, no validity check needed
         if self.timestamp_authorities.is_empty() {
-            return true;
+            return Ok(true);
         }
 
         for tsa in &self.timestamp_authorities {
             // If a TSA has no valid_for constraint, it's valid for all time
             let Some(valid_for) = &tsa.valid_for else {
-                return true;
+                return Ok(true);
             };
 
-            let start = valid_for
-                .start
-                .as_ref()
-                .and_then(|s| s.parse::<Timestamp>().ok());
-            let end = valid_for
-                .end
-                .as_ref()
-                .and_then(|s| s.parse::<Timestamp>().ok());
-
             // Check if timestamp falls within this TSA's validity period
-            let after_start = start.map_or(true, |s| timestamp >= s);
-            let before_end = end.map_or(true, |e| timestamp <= e);
-
-            if after_start && before_end {
-                return true;
+            if valid_for.contains(timestamp)? {
+                return Ok(true);
             }
         }
 
         // No TSA's validity period matched
-        false
+        Ok(false)
     }
 }
 
@@ -538,5 +670,248 @@ mod tests {
             .certificate_authorities
             .iter()
             .any(|ca| ca.uri == "fulcio.githubapp.com"));
+    }
+
+    // A dummy DER-encoded P-256 public key (base64), reused across instances.
+    const TEST_KEY: &str = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYI4heOTrNrZO27elFE8ynfrdPMikttRkbe+vJKQ50G6bfwQ3WyhLpRwwwohelDAm8xRzJ56nYsIa3VHivVvpmA==";
+
+    fn trusted_root_with_tlog_validity(valid_for: &[(&str, &str)]) -> TrustedRoot {
+        let tlogs: Vec<String> = valid_for
+            .iter()
+            .enumerate()
+            .map(|(i, (key_id, validity))| {
+                format!(
+                    r#"{{
+                        "baseUrl": "https://rekor-{i}.example.com",
+                        "hashAlgorithm": "SHA2_256",
+                        "publicKey": {{
+                            "rawBytes": "{TEST_KEY}",
+                            "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+                            "validFor": {validity}
+                        }},
+                        "logId": {{ "keyId": "{key_id}" }}
+                    }}"#
+                )
+            })
+            .collect();
+        let json = format!(
+            r#"{{
+                "mediaType": "application/vnd.dev.sigstore.trustedroot+json;version=0.1",
+                "tlogs": [{}]
+            }}"#,
+            tlogs.join(",")
+        );
+        TrustedRoot::from_json(&json).unwrap()
+    }
+
+    #[test]
+    fn test_rekor_keys_excludes_not_yet_valid() {
+        let root = trusted_root_with_tlog_validity(&[
+            // Expired key: usable for verifying historical entries
+            (
+                "expired-key",
+                r#"{"start": "2020-01-01T00:00:00Z", "end": "2021-01-01T00:00:00Z"}"#,
+            ),
+            // Currently valid key
+            ("current-key", r#"{"start": "2021-01-01T00:00:00Z"}"#),
+            // Key whose validity window has not started yet
+            ("future-key", r#"{"start": "2999-01-01T00:00:00Z"}"#),
+        ]);
+
+        let keys = root.rekor_keys().unwrap();
+        assert_eq!(keys.len(), 2);
+        assert!(keys.contains_key("expired-key"));
+        assert!(keys.contains_key("current-key"));
+        assert!(!keys.contains_key("future-key"));
+
+        // rekor_key_for_log honors the same rule
+        assert!(root
+            .rekor_key_for_log(&LogKeyId::new("expired-key".to_string()))
+            .is_ok());
+        assert!(root
+            .rekor_key_for_log(&LogKeyId::new("current-key".to_string()))
+            .is_ok());
+        assert!(matches!(
+            root.rekor_key_for_log(&LogKeyId::new("future-key".to_string())),
+            Err(Error::KeyNotFound(_))
+        ));
+    }
+
+    #[test]
+    fn test_rekor_key_for_log_at_checks_full_window() {
+        let root = trusted_root_with_tlog_validity(&[(
+            "windowed-key",
+            r#"{"start": "2020-01-01T00:00:00Z", "end": "2021-01-01T00:00:00Z"}"#,
+        )]);
+        let key_id = LogKeyId::new("windowed-key".to_string());
+
+        // Inside the window
+        let inside: Timestamp = "2020-06-01T00:00:00Z".parse().unwrap();
+        assert!(root.rekor_key_for_log_at(&key_id, inside).is_ok());
+
+        // Before the window
+        let before: Timestamp = "2019-06-01T00:00:00Z".parse().unwrap();
+        assert!(root.rekor_key_for_log_at(&key_id, before).is_err());
+
+        // After the window
+        let after: Timestamp = "2022-06-01T00:00:00Z".parse().unwrap();
+        assert!(root.rekor_key_for_log_at(&key_id, after).is_err());
+    }
+
+    #[test]
+    fn test_rekor_keys_malformed_timestamp_is_error() {
+        let root =
+            trusted_root_with_tlog_validity(&[("bad-key", r#"{"start": "not-a-timestamp"}"#)]);
+
+        assert!(matches!(root.rekor_keys(), Err(Error::TimeParse(_))));
+        assert!(matches!(
+            root.rekor_keys_with_hints(),
+            Err(Error::TimeParse(_))
+        ));
+        assert!(matches!(
+            root.rekor_key_for_log(&LogKeyId::new("bad-key".to_string())),
+            Err(Error::TimeParse(_))
+        ));
+    }
+
+    #[test]
+    fn test_ctfe_keys_exclude_not_yet_valid_and_error_on_malformed() {
+        let json = format!(
+            r#"{{
+                "mediaType": "application/vnd.dev.sigstore.trustedroot+json;version=0.1",
+                "ctlogs": [
+                    {{
+                        "baseUrl": "https://ctfe-current.example.com",
+                        "hashAlgorithm": "SHA2_256",
+                        "publicKey": {{
+                            "rawBytes": "{TEST_KEY}",
+                            "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+                            "validFor": {{"start": "2021-01-01T00:00:00Z"}}
+                        }},
+                        "logId": {{ "keyId": "current-ctlog" }}
+                    }},
+                    {{
+                        "baseUrl": "https://ctfe-future.example.com",
+                        "hashAlgorithm": "SHA2_256",
+                        "publicKey": {{
+                            "rawBytes": "{TEST_KEY}",
+                            "keyDetails": "PKIX_ECDSA_P256_SHA_256",
+                            "validFor": {{"start": "2999-01-01T00:00:00Z"}}
+                        }},
+                        "logId": {{ "keyId": "future-ctlog" }}
+                    }}
+                ]
+            }}"#
+        );
+        let root = TrustedRoot::from_json(&json).unwrap();
+
+        let keys = root.ctfe_keys().unwrap();
+        assert_eq!(keys.len(), 1);
+        assert!(keys.contains_key(&LogKeyId::new("current-ctlog".to_string())));
+
+        assert_eq!(root.ctfe_keys_with_ids().unwrap().len(), 1);
+
+        // Malformed timestamp produces an error
+        let bad_json = json.replace("2999-01-01T00:00:00Z", "garbage");
+        let bad_root = TrustedRoot::from_json(&bad_json).unwrap();
+        assert!(matches!(bad_root.ctfe_keys(), Err(Error::TimeParse(_))));
+        assert!(matches!(
+            bad_root.ctfe_keys_with_ids(),
+            Err(Error::TimeParse(_))
+        ));
+    }
+
+    #[test]
+    fn test_fulcio_certs_exclude_not_yet_valid() {
+        // raw cert bytes are not parsed by fulcio_certs, so dummy DER is fine here
+        let json = r#"{
+            "mediaType": "application/vnd.dev.sigstore.trustedroot+json;version=0.1",
+            "certificateAuthorities": [
+                {
+                    "uri": "https://fulcio-expired.example.com",
+                    "certChain": { "certificates": [{ "rawBytes": "AAAA" }] },
+                    "validFor": {"start": "2020-01-01T00:00:00Z", "end": "2021-01-01T00:00:00Z"}
+                },
+                {
+                    "uri": "https://fulcio-current.example.com",
+                    "certChain": { "certificates": [{ "rawBytes": "AAAA" }] },
+                    "validFor": {"start": "2021-01-01T00:00:00Z"}
+                },
+                {
+                    "uri": "https://fulcio-future.example.com",
+                    "certChain": { "certificates": [{ "rawBytes": "AAAA" }] },
+                    "validFor": {"start": "2999-01-01T00:00:00Z"}
+                }
+            ]
+        }"#;
+        let root = TrustedRoot::from_json(json).unwrap();
+
+        // Expired CA is kept (verifies historical certificates), future CA is excluded
+        let certs = root.fulcio_certs().unwrap();
+        assert_eq!(certs.len(), 2);
+    }
+
+    const TSA_TRUSTED_ROOT: &str = r#"{
+        "mediaType": "application/vnd.dev.sigstore.trustedroot+json;version=0.1",
+        "timestampAuthorities": [{
+            "uri": "https://tsa.example.com",
+            "certChain": { "certificates": [{ "rawBytes": "AAAA" }] },
+            "validFor": {"start": "BAD-TIMESTAMP", "end": "2030-01-01T00:00:00Z"}
+        }]
+    }"#;
+
+    #[test]
+    fn test_tsa_malformed_timestamp_is_error() {
+        let root = TrustedRoot::from_json(TSA_TRUSTED_ROOT).unwrap();
+        let now = Timestamp::now();
+
+        assert!(matches!(
+            root.tsa_certs_with_validity(),
+            Err(Error::TimeParse(_))
+        ));
+        assert!(matches!(
+            root.is_timestamp_within_tsa_validity(now),
+            Err(Error::TimeParse(_))
+        ));
+        assert!(matches!(
+            root.tsa_validity_for_time(now),
+            Err(Error::TimeParse(_))
+        ));
+        assert!(matches!(root.tsa_root_certs(), Err(Error::TimeParse(_))));
+        assert!(matches!(root.tsa_leaf_certs(), Err(Error::TimeParse(_))));
+    }
+
+    #[test]
+    fn test_validity_period_contains() {
+        let period = ValidityPeriod {
+            start: Some("2020-01-01T00:00:00Z".to_string()),
+            end: Some("2021-01-01T00:00:00Z".to_string()),
+        };
+        let inside: Timestamp = "2020-06-01T00:00:00Z".parse().unwrap();
+        let before: Timestamp = "2019-06-01T00:00:00Z".parse().unwrap();
+        let after: Timestamp = "2022-06-01T00:00:00Z".parse().unwrap();
+
+        assert!(period.contains(inside).unwrap());
+        assert!(!period.contains(before).unwrap());
+        assert!(!period.contains(after).unwrap());
+
+        assert!(period.has_started_by(inside).unwrap());
+        assert!(period.has_started_by(after).unwrap());
+        assert!(!period.has_started_by(before).unwrap());
+
+        // Open-ended period
+        let open = ValidityPeriod {
+            start: Some("2020-01-01T00:00:00Z".to_string()),
+            end: None,
+        };
+        assert!(open.contains(after).unwrap());
+
+        // Malformed timestamps surface as errors
+        let bad = ValidityPeriod {
+            start: Some("garbage".to_string()),
+            end: None,
+        };
+        assert!(matches!(bad.contains(inside), Err(Error::TimeParse(_))));
+        assert!(matches!(bad.start(), Err(Error::TimeParse(_))));
     }
 }

--- a/crates/sigstore-verify/src/verify_impl/helpers.rs
+++ b/crates/sigstore-verify/src/verify_impl/helpers.rs
@@ -99,7 +99,15 @@ pub fn extract_tsa_timestamp(
         })?;
 
         // Check that the timestamp falls within the TSA's validity period from the trust root
-        if !trusted_root.is_timestamp_within_tsa_validity(result.time) {
+        let within_validity = trusted_root
+            .is_timestamp_within_tsa_validity(result.time)
+            .map_err(|e| {
+                Error::Verification(format!(
+                    "invalid TSA validity period in trusted root: {}",
+                    e
+                ))
+            })?;
+        if !within_validity {
             return Err(Error::Verification(format!(
                 "TSA timestamp {} is outside the trust root's TSA validity period",
                 result.time

--- a/crates/sigstore-verify/src/verify_impl/tlog.rs
+++ b/crates/sigstore-verify/src/verify_impl/tlog.rs
@@ -146,15 +146,34 @@ pub fn verify_set(entry: &TransparencyLogEntry, trusted_root: &TrustedRoot) -> R
         .as_ref()
         .ok_or(Error::Verification("Missing inclusion promise".into()))?;
 
-    // Find the key for the log ID
-    let log_key = trusted_root
-        .rekor_key_for_log(&entry.log_id.key_id)
-        .map_err(|_| Error::Verification(format!("Unknown log ID: {}", entry.log_id.key_id)))?;
+    let integrated_time = entry.integrated_time;
+
+    // Find the key for the log ID. When the entry carries a real integrated
+    // time, require the log key's validity window to cover it: an entry must
+    // have been integrated while the log key was valid.
+    let log_key = if integrated_time > 0 {
+        let integrated_ts = jiff::Timestamp::from_second(integrated_time).map_err(|e| {
+            Error::Verification(format!(
+                "Invalid integrated time {}: {}",
+                integrated_time, e
+            ))
+        })?;
+        trusted_root
+            .rekor_key_for_log_at(&entry.log_id.key_id, integrated_ts)
+            .map_err(|e| {
+                Error::Verification(format!(
+                    "No log key valid at integrated time {} for log ID {}: {}",
+                    integrated_ts, entry.log_id.key_id, e
+                ))
+            })?
+    } else {
+        trusted_root
+            .rekor_key_for_log(&entry.log_id.key_id)
+            .map_err(|_| Error::Verification(format!("Unknown log ID: {}", entry.log_id.key_id)))?
+    };
 
     // Construct the payload (base64-encoded body)
     let body = entry.canonicalized_body.to_base64();
-
-    let integrated_time = entry.integrated_time;
     let log_index = entry
         .log_index
         .as_u64()


### PR DESCRIPTION
Fixes the two problems from #112: accessors like `rekor_keys()` ignored `valid_for`, and `valid_for` timestamp parsing silently swallowed errors (`.parse().ok()` treated malformed timestamps as unbounded validity).

**Semantics chosen** (matching sigstore-go's `RekorLogs` and sigstore-python's verify-path behavior):

- All verification-material accessors (`rekor_keys`, `rekor_keys_with_hints`, `rekor_key_for_log`, `ctfe_keys`, `ctfe_keys_with_ids`, `fulcio_certs`, `tsa_root_certs`, `tsa_intermediate_certs`, `tsa_leaf_certs`) now **exclude instances whose `valid_for.start` is in the future** and **propagate timestamp parse errors** instead of ignoring them.
- **Expired instances are deliberately kept**: they're required to verify historical material (the embedded production/GitHub trusted roots contain expired ctlogs/CAs/TSAs that are still needed to verify old bundles). Filtering to a strict now-window would have broken verification of all pre-2025 GitHub attestations.
- Where the relevant time IS known, the full window is enforced: new `rekor_key_for_log_at(log_id, time)` requires the window to contain `time`, and `verify_set()` now uses it with the entry's integrated time — a SET only verifies if the entry was integrated while the log key was valid (matches sigstore-go).
- New `ValidityPeriod` API: `start()`, `end()`, `contains(time)`, `has_started_by(time)`, all returning `Result` so malformed timestamps error.

**Breaking change**: `is_timestamp_within_tsa_validity()` now returns `Result<bool>`; its caller in sigstore-verify fails verification on malformed trust-root timestamps instead of silently passing.

Seven new unit tests cover future-key exclusion, expired-key retention, full-window checks in `rekor_key_for_log_at`, and malformed-timestamp errors across rekor/ctlog/fulcio/TSA accessors. `cargo clippy --workspace -D warnings` clean, full workspace test suite passes.

Fixes #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)