### PR TITLE
bundle: separate structural validation from crypto verification

### DIFF
--- a/crates/sigstore-bundle/Cargo.toml
+++ b/crates/sigstore-bundle/Cargo.toml
@@ -15,7 +15,6 @@ native-tls = ["sigstore-tsa/native-tls", "sigstore-rekor/native-tls"]
 [dependencies]
 sigstore-types = { workspace = true }
 sigstore-crypto = { workspace = true }
-sigstore-merkle = { workspace = true }
 sigstore-tsa = { workspace = true, default-features = false }
 sigstore-rekor = { workspace = true, default-features = false }
 serde = { workspace = true }
@@ -26,3 +25,4 @@ hex = { workspace = true }
 
 [dev-dependencies]
 hex = { workspace = true }
+sigstore-merkle = { workspace = true }

--- a/crates/sigstore-bundle/src/error.rs
+++ b/crates/sigstore-bundle/src/error.rs
@@ -12,10 +12,6 @@ pub enum Error {
     /// JSON error
     #[error("JSON error: {0}")]
     Json(#[from] serde_json::Error),
-
-    /// Merkle proof error
-    #[error("Merkle proof error: {0}")]
-    Merkle(#[from] sigstore_merkle::Error),
 }
 
 /// Result type for bundle operations

--- a/crates/sigstore-bundle/src/lib.rs
+++ b/crates/sigstore-bundle/src/lib.rs
@@ -1,7 +1,13 @@
 //! Bundle format handling for Sigstore
 //!
-//! This crate handles creation, parsing, and validation of Sigstore bundles
-//! (versions 0.1, 0.2, and 0.3).
+//! This crate handles creation, parsing, and *structural* validation of
+//! Sigstore bundles (versions 0.1, 0.2, and 0.3).
+//!
+//! Note that [`validate_bundle`] and [`validate_bundle_with_options`] only
+//! check bundle shape and version conformance; they perform no cryptographic
+//! verification. Use the `sigstore-verify` crate to cryptographically verify
+//! a bundle (signatures, inclusion proofs, checkpoints, SETs, timestamps and
+//! certificates).
 
 pub mod builder;
 pub mod error;

--- a/crates/sigstore-bundle/src/validation.rs
+++ b/crates/sigstore-bundle/src/validation.rs
@@ -1,17 +1,39 @@
-//! Bundle validation
+//! Structural bundle validation
 //!
-//! Validates Sigstore bundles according to version-specific rules.
+//! This module performs *structural* validation of Sigstore bundles: it
+//! checks that a bundle has the shape and required fields mandated by its
+//! media-type version (v0.1, v0.2, v0.3).
+//!
+//! It deliberately performs **no cryptographic verification**. In
+//! particular, the functions in this module do NOT:
+//!
+//! - verify the artifact or DSSE signature,
+//! - verify Merkle inclusion proofs against the log root,
+//! - verify checkpoint (signed tree head) signatures,
+//! - verify inclusion promises (SETs),
+//! - verify RFC 3161 timestamps,
+//! - verify the certificate chain or certificate contents.
+//!
+//! Cryptographic verification of all of the above is the responsibility of
+//! the verification path in the `sigstore-verify` crate (see
+//! `sigstore_verify::verify` / `Verifier`), which has access to the trusted
+//! root material required to do so.
 
 use crate::error::{Error, Result};
-use sigstore_merkle::verify_inclusion_proof;
-use sigstore_types::{Bundle, MediaType, Sha256Hash};
+use sigstore_types::{Bundle, MediaType};
 
-/// Validation options
+/// Options controlling which materials must be *present* in the bundle.
+///
+/// These options only affect presence/shape requirements; they never enable
+/// cryptographic checks (structural validation performs none).
 #[derive(Debug, Clone)]
 pub struct ValidationOptions {
-    /// Require inclusion proof (not just promise)
+    /// Require an inclusion proof to be present (not just an inclusion
+    /// promise). Note that presence is all that is checked; the proof is
+    /// not cryptographically verified here.
     pub require_inclusion_proof: bool,
-    /// Require timestamp verification data
+    /// Require RFC 3161 timestamp verification data to be present. The
+    /// timestamps themselves are not verified here.
     pub require_timestamp: bool,
 }
 
@@ -24,12 +46,57 @@ impl Default for ValidationOptions {
     }
 }
 
-/// Validate a Sigstore bundle
+/// Structurally validate a Sigstore bundle using default [`ValidationOptions`].
+///
+/// This is a purely *structural* check: it confirms the bundle conforms to
+/// the shape required by its media-type version. See
+/// [`validate_bundle_with_options`] for the full list of what is and is not
+/// checked.
+///
+/// # What this does NOT do
+///
+/// No cryptographic verification is performed: signatures, Merkle inclusion
+/// proofs, checkpoint signatures, inclusion promises (SETs), timestamps and
+/// certificates are **not** verified. A bundle passing this function may
+/// still be forged or tampered with; use `sigstore-verify` to actually
+/// verify it.
 pub fn validate_bundle(bundle: &Bundle) -> Result<()> {
     validate_bundle_with_options(bundle, &ValidationOptions::default())
 }
 
-/// Validate a Sigstore bundle with custom options
+/// Structurally validate a Sigstore bundle with custom options.
+///
+/// # What is checked (structural only)
+///
+/// - The media type is a known bundle version (v0.1, v0.2, v0.3).
+/// - Version-specific shape requirements:
+///   - v0.1: an inclusion promise (SET) must be present.
+///   - v0.2/v0.3: an inclusion proof must be present (if
+///     [`ValidationOptions::require_inclusion_proof`] is set).
+///   - v0.3: the verification material must be a single certificate or a
+///     public key, not a certificate chain.
+/// - Each inclusion proof that is present is well-formed: its checkpoint
+///   envelope parses, its `log_index`/`tree_size` are in range, and its
+///   `root_hash` is consistent with the root hash embedded in its
+///   checkpoint. (Consistency between two fields of the same bundle is a
+///   well-formedness check, not a trust decision.)
+/// - At least one transparency log entry or RFC 3161 timestamp is present
+///   (depending on options).
+///
+/// # What is NOT checked
+///
+/// No cryptographic verification of any kind is performed. In particular,
+/// this function does **not**:
+///
+/// - verify the artifact or DSSE signature,
+/// - verify Merkle inclusion proofs against the log root,
+/// - verify checkpoint (signed tree head) signatures,
+/// - verify inclusion promises (SETs),
+/// - verify RFC 3161 timestamps,
+/// - verify the certificate chain or its contents.
+///
+/// Those checks require trusted key material and are performed by the
+/// verification path in the `sigstore-verify` crate.
 pub fn validate_bundle_with_options(bundle: &Bundle, options: &ValidationOptions) -> Result<()> {
     // Check media type is valid
     let version = bundle
@@ -44,7 +111,7 @@ pub fn validate_bundle_with_options(bundle: &Bundle, options: &ValidationOptions
     }
 }
 
-/// Validate a v0.1 bundle
+/// Structurally validate a v0.1 bundle
 fn validate_v0_1(bundle: &Bundle, options: &ValidationOptions) -> Result<()> {
     // v0.1 requires inclusion promise (SET)
     if !bundle.has_inclusion_promise() {
@@ -53,14 +120,15 @@ fn validate_v0_1(bundle: &Bundle, options: &ValidationOptions) -> Result<()> {
         ));
     }
 
-    // Validate inclusion proofs if present (v0.1 may have both promise and proof)
-    validate_inclusion_proofs(bundle)?;
+    // Check well-formedness of inclusion proofs if present
+    // (v0.1 may have both promise and proof)
+    validate_inclusion_proof_structure(bundle)?;
 
     // Common validation
     validate_common(bundle, options)
 }
 
-/// Validate a v0.2 bundle
+/// Structurally validate a v0.2 bundle
 fn validate_v0_2(bundle: &Bundle, options: &ValidationOptions) -> Result<()> {
     // v0.2 requires inclusion proof with checkpoint
     if options.require_inclusion_proof && !bundle.has_inclusion_proof() {
@@ -69,14 +137,14 @@ fn validate_v0_2(bundle: &Bundle, options: &ValidationOptions) -> Result<()> {
         ));
     }
 
-    // Validate inclusion proofs
-    validate_inclusion_proofs(bundle)?;
+    // Check well-formedness of inclusion proofs
+    validate_inclusion_proof_structure(bundle)?;
 
     // Common validation
     validate_common(bundle, options)
 }
 
-/// Validate a v0.3 bundle
+/// Structurally validate a v0.3 bundle
 fn validate_v0_3(bundle: &Bundle, options: &ValidationOptions) -> Result<()> {
     // v0.3 must have single certificate (not chain) or public key
     match &bundle.verification_material.content {
@@ -96,14 +164,14 @@ fn validate_v0_3(bundle: &Bundle, options: &ValidationOptions) -> Result<()> {
         ));
     }
 
-    // Validate inclusion proofs
-    validate_inclusion_proofs(bundle)?;
+    // Check well-formedness of inclusion proofs
+    validate_inclusion_proof_structure(bundle)?;
 
     // Common validation
     validate_common(bundle, options)
 }
 
-/// Common validation for all bundle versions
+/// Common structural validation for all bundle versions
 fn validate_common(bundle: &Bundle, options: &ValidationOptions) -> Result<()> {
     let has_tlog_entries = !bundle.verification_material.tlog_entries.is_empty();
     let has_timestamp = !bundle
@@ -130,23 +198,29 @@ fn validate_common(bundle: &Bundle, options: &ValidationOptions) -> Result<()> {
     Ok(())
 }
 
-/// Validate inclusion proofs in the bundle
-fn validate_inclusion_proofs(bundle: &Bundle) -> Result<()> {
+/// Check that any inclusion proofs in the bundle are well-formed.
+///
+/// This is a structural check only:
+///
+/// - the checkpoint envelope must parse as a signed note,
+/// - `log_index` and `tree_size` must be valid and in range
+///   (`log_index < tree_size`),
+/// - the proof's `root_hash` must equal the root hash embedded in its own
+///   checkpoint (internal consistency between two fields of the bundle).
+///
+/// It does NOT verify the Merkle proof against the root hash, and it does
+/// NOT verify the checkpoint signature. Those cryptographic checks are
+/// performed by the verification path in `sigstore-verify`.
+fn validate_inclusion_proof_structure(bundle: &Bundle) -> Result<()> {
     for entry in &bundle.verification_material.tlog_entries {
         if let Some(proof) = &entry.inclusion_proof {
-            // Parse the checkpoint to get the expected root
+            // The checkpoint must be a parseable signed note
             let checkpoint = proof
                 .checkpoint
                 .parse()
                 .map_err(|e| Error::Validation(format!("failed to parse checkpoint: {}", e)))?;
 
-            // Get the leaf (canonicalized body) bytes
-            let leaf_data = entry.canonicalized_body.as_bytes();
-
-            // Get proof hashes (already decoded as Vec<Sha256Hash>)
-            let proof_hashes: &[Sha256Hash] = &proof.hashes;
-
-            // Get indices (now i64 internally)
+            // Indices must be valid and in range
             let leaf_index: u64 = proof
                 .log_index
                 .as_u64()
@@ -155,24 +229,22 @@ fn validate_inclusion_proofs(bundle: &Bundle) -> Result<()> {
                 .tree_size
                 .try_into()
                 .map_err(|_| Error::Validation("invalid tree_size in proof".to_string()))?;
+            if leaf_index >= tree_size {
+                return Err(Error::Validation(format!(
+                    "inclusion proof log_index {} out of range for tree_size {}",
+                    leaf_index, tree_size
+                )));
+            }
 
-            // Get expected root from checkpoint (already a Sha256Hash)
-            let expected_root = checkpoint.root_hash;
-
-            // Hash the leaf
-            let leaf_hash = sigstore_merkle::hash_leaf(leaf_data);
-
-            // Verify the inclusion proof
-            verify_inclusion_proof(
-                &leaf_hash,
-                leaf_index,
-                tree_size,
-                proof_hashes,
-                &expected_root,
-            )
-            .map_err(|e| {
-                Error::Validation(format!("inclusion proof verification failed: {}", e))
-            })?;
+            // The proof's root hash must be consistent with the root hash
+            // recorded in its own checkpoint. This is internal consistency
+            // of the bundle, not a trust decision: neither hash has been
+            // authenticated at this point.
+            if checkpoint.root_hash != proof.root_hash {
+                return Err(Error::Validation(
+                    "inclusion proof root hash does not match checkpoint root hash".to_string(),
+                ));
+            }
         }
     }
 

--- a/crates/sigstore-bundle/tests/bundle_versions_tests.rs
+++ b/crates/sigstore-bundle/tests/bundle_versions_tests.rs
@@ -3,7 +3,7 @@
 //! These tests use real bundle fixtures from sigstore-rs and sigstore-python.
 
 use sigstore_bundle::{validate_bundle, validate_bundle_with_options, ValidationOptions};
-use sigstore_types::Bundle;
+use sigstore_types::{Bundle, Sha256Hash};
 
 /// v0.1 bundle with x509CertificateChain (from sigstore-rs)
 const V01_BUNDLE: &str = r#"{
@@ -374,6 +374,74 @@ fn test_v03_with_certificate_chain_fails() {
     assert!(
         err_msg.contains("single certificate"),
         "Error should mention single certificate requirement"
+    );
+}
+
+// ==== Structural-Only Contract Tests ====
+//
+// validate_bundle() is purely structural: it must NOT perform cryptographic
+// verification (Merkle proofs, checkpoint signatures, SETs, ...). These tests
+// pin that contract; the crypto checks live in sigstore-verify.
+
+#[test]
+fn test_structural_validation_does_not_verify_inclusion_proof_crypto() {
+    let mut bundle = Bundle::from_json(V03_BUNDLE_WITH_PROOF).expect("Failed to parse bundle");
+
+    // Tamper with the Merkle proof hashes. The proof is now cryptographically
+    // invalid, but still structurally well-formed.
+    let proof = bundle.verification_material.tlog_entries[0]
+        .inclusion_proof
+        .as_mut()
+        .expect("bundle has inclusion proof");
+    proof.hashes[0] = Sha256Hash::from_bytes([0u8; 32]);
+
+    let result = validate_bundle(&bundle);
+    assert!(
+        result.is_ok(),
+        "structural validation must not verify Merkle proofs (crypto belongs to sigstore-verify): {:?}",
+        result.err()
+    );
+}
+
+#[test]
+fn test_structural_validation_rejects_root_hash_mismatch() {
+    let mut bundle = Bundle::from_json(V03_BUNDLE_WITH_PROOF).expect("Failed to parse bundle");
+
+    // A proof whose root hash disagrees with its own checkpoint is malformed.
+    let proof = bundle.verification_material.tlog_entries[0]
+        .inclusion_proof
+        .as_mut()
+        .expect("bundle has inclusion proof");
+    proof.root_hash = Sha256Hash::from_bytes([0u8; 32]);
+
+    let result = validate_bundle(&bundle);
+    assert!(
+        result.is_err(),
+        "proof root hash inconsistent with checkpoint root hash should fail structural validation"
+    );
+    let err_msg = format!("{:?}", result.err());
+    assert!(
+        err_msg.contains("root hash"),
+        "Error should mention root hash mismatch: {}",
+        err_msg
+    );
+}
+
+#[test]
+fn test_structural_validation_rejects_out_of_range_log_index() {
+    let mut bundle = Bundle::from_json(V03_BUNDLE_WITH_PROOF).expect("Failed to parse bundle");
+
+    // log_index must be < tree_size
+    let proof = bundle.verification_material.tlog_entries[0]
+        .inclusion_proof
+        .as_mut()
+        .expect("bundle has inclusion proof");
+    proof.log_index = sigstore_types::LogIndex::new(proof.tree_size);
+
+    let result = validate_bundle(&bundle);
+    assert!(
+        result.is_err(),
+        "log_index >= tree_size should fail structural validation"
     );
 }
 

--- a/crates/sigstore-verify/src/verify.rs
+++ b/crates/sigstore-verify/src/verify.rs
@@ -233,7 +233,9 @@ impl Verifier {
         let artifact = artifact.into();
         let mut result = VerificationResult::success();
 
-        // Validate bundle structure first
+        // Validate bundle structure first. This is a purely structural
+        // (shape/required-fields) check; all cryptographic verification of
+        // the bundle's contents happens in the steps below.
         let options = ValidationOptions {
             require_inclusion_proof: policy.verify_tlog,
             require_timestamp: false, // Don't require timestamps, but verify if present
@@ -569,7 +571,7 @@ pub fn verify<'a>(
 ///
 /// This verification:
 /// - Verifies the signature using the provided public key
-/// - Verifies transparency log entries (checkpoints, SETs)
+/// - Verifies transparency log entries (Merkle inclusion proofs, checkpoints, SETs)
 /// - Skips certificate chain verification (no certificate present)
 /// - Skips identity/issuer verification
 ///
@@ -605,7 +607,8 @@ pub fn verify_with_key<'a>(
     let artifact = artifact.into();
     let result = VerificationResult::success();
 
-    // Validate bundle structure
+    // Validate bundle structure (structural only; the cryptographic checks
+    // follow below)
     let options = ValidationOptions {
         require_inclusion_proof: true,
         require_timestamp: false,
@@ -624,21 +627,10 @@ pub fn verify_with_key<'a>(
         }
     };
 
-    // Verify transparency log entries (checkpoints, SETs) without certificate time validation
+    // Verify transparency log entries (Merkle inclusion proofs, checkpoints,
+    // SETs) without certificate time validation
     for entry in &bundle.verification_material.tlog_entries {
-        // Verify checkpoint signature if present
-        if let Some(ref inclusion_proof) = entry.inclusion_proof {
-            crate::verify_impl::tlog::verify_checkpoint(
-                &inclusion_proof.checkpoint.envelope,
-                inclusion_proof,
-                trusted_root,
-            )?;
-        }
-
-        // Verify inclusion promise (SET) if present
-        if entry.inclusion_promise.is_some() {
-            crate::verify_impl::tlog::verify_set(entry, trusted_root)?;
-        }
+        crate::verify_impl::tlog::verify_entry_inclusion(entry, trusted_root)?;
     }
 
     // Verify the signature

--- a/crates/sigstore-verify/src/verify_impl/tlog.rs
+++ b/crates/sigstore-verify/src/verify_impl/tlog.rs
@@ -11,7 +11,18 @@ use sigstore_trust_root::TrustedRoot;
 use sigstore_types::bundle::InclusionProof;
 use sigstore_types::{Bundle, SignatureBytes, TransparencyLogEntry};
 
-/// Verify transparency log entries (checkpoints and SETs)
+/// Verify transparency log entries (checkpoints, Merkle inclusion proofs and SETs)
+///
+/// For every tlog entry this cryptographically verifies (via
+/// [`verify_entry_inclusion`]):
+/// - the Merkle inclusion proof of the entry's canonicalized body against
+///   the proof's root hash (if an inclusion proof is present),
+/// - the checkpoint signature with the Rekor keys from the trusted root,
+///   and that the checkpoint's root hash matches the proof's root hash,
+/// - the inclusion promise (SET), if present.
+///
+/// It also validates the entry's integrated time against the certificate
+/// validity window.
 ///
 /// # Arguments
 /// * `bundle` - The bundle containing transparency log entries
@@ -29,19 +40,8 @@ pub fn verify_tlog_entries(
     let mut integrated_time_result: Option<i64> = None;
 
     for entry in &bundle.verification_material.tlog_entries {
-        // Verify checkpoint signature if present
-        if let Some(ref inclusion_proof) = entry.inclusion_proof {
-            verify_checkpoint(
-                &inclusion_proof.checkpoint.envelope,
-                inclusion_proof,
-                trusted_root,
-            )?;
-        }
-
-        // Verify inclusion promise (SET) if present
-        if entry.inclusion_promise.is_some() {
-            verify_set(entry, trusted_root)?;
-        }
+        // Verify Merkle inclusion proof, checkpoint signature and SET
+        verify_entry_inclusion(entry, trusted_root)?;
 
         // Validate integrated time (0 indicates missing/invalid time in v2 entries)
         let time = entry.integrated_time;
@@ -75,6 +75,69 @@ pub fn verify_tlog_entries(
     }
 
     Ok(integrated_time_result)
+}
+
+/// Cryptographically verify the log-inclusion material of a single tlog entry.
+///
+/// This performs all per-entry transparency log crypto checks:
+/// - If an inclusion proof is present:
+///   - verifies the Merkle inclusion proof, i.e. that the leaf hash of the
+///     entry's canonicalized body hashes up to the proof's root hash, and
+///   - verifies the checkpoint: its root hash must match the proof's root
+///     hash, and its signature must verify against a Rekor key from the
+///     trusted root (see [`verify_checkpoint`]).
+/// - If an inclusion promise (SET) is present, verifies it against the
+///   Rekor key for the entry's log ID (see [`verify_set`]).
+///
+/// Time-related checks (integrated time vs. certificate validity) are not
+/// performed here; see [`verify_tlog_entries`].
+pub fn verify_entry_inclusion(
+    entry: &TransparencyLogEntry,
+    trusted_root: &TrustedRoot,
+) -> Result<()> {
+    if let Some(ref inclusion_proof) = entry.inclusion_proof {
+        verify_merkle_inclusion(entry, inclusion_proof)?;
+        verify_checkpoint(
+            &inclusion_proof.checkpoint.envelope,
+            inclusion_proof,
+            trusted_root,
+        )?;
+    }
+
+    if entry.inclusion_promise.is_some() {
+        verify_set(entry, trusted_root)?;
+    }
+
+    Ok(())
+}
+
+/// Verify the Merkle inclusion proof of a tlog entry.
+///
+/// Computes the leaf hash of the entry's canonicalized body and verifies
+/// that, combined with the proof hashes, it reproduces the proof's root
+/// hash. Note that this alone does not authenticate the root hash; the
+/// accompanying checkpoint signature check in [`verify_checkpoint`] binds
+/// the root hash to a key in the trusted root.
+fn verify_merkle_inclusion(entry: &TransparencyLogEntry, proof: &InclusionProof) -> Result<()> {
+    let leaf_index: u64 = proof
+        .log_index
+        .as_u64()
+        .ok_or_else(|| Error::Verification("invalid log_index in inclusion proof".to_string()))?;
+    let tree_size: u64 = proof
+        .tree_size
+        .try_into()
+        .map_err(|_| Error::Verification("invalid tree_size in inclusion proof".to_string()))?;
+
+    let leaf_hash = sigstore_merkle::hash_leaf(entry.canonicalized_body.as_bytes());
+
+    sigstore_merkle::verify_inclusion_proof(
+        &leaf_hash,
+        leaf_index,
+        tree_size,
+        &proof.hashes,
+        &proof.root_hash,
+    )
+    .map_err(|e| Error::Verification(format!("inclusion proof verification failed: {}", e)))
 }
 
 /// Verify a checkpoint signature using the trusted root

--- a/crates/sigstore-verify/tests/verification_tests.rs
+++ b/crates/sigstore-verify/tests/verification_tests.rs
@@ -138,20 +138,55 @@ fn test_validate_bundle_with_inclusion_proof() {
 }
 
 #[test]
-fn test_validate_bundle_merkle_proof() {
-    let bundle = Bundle::from_json(V03_BUNDLE_DSSE).unwrap();
+fn test_tampered_inclusion_proof_fails_verification() {
+    let mut bundle = Bundle::from_json(V03_BUNDLE_DSSE).unwrap();
 
-    // This validates the Merkle inclusion proof
-    let options = ValidationOptions {
-        require_inclusion_proof: true,
-        require_timestamp: false,
-    };
+    // Tamper with the Merkle inclusion proof hashes.
+    let proof = bundle.verification_material.tlog_entries[0]
+        .inclusion_proof
+        .as_mut()
+        .expect("bundle has inclusion proof");
+    proof.hashes[0] = Sha256Hash::from_bytes([0u8; 32]);
 
-    let result = validate_bundle_with_options(&bundle, &options);
+    // Structural validation intentionally performs no crypto, so the
+    // tampered bundle still passes it...
     assert!(
-        result.is_ok(),
-        "Merkle proof validation failed: {:?}",
-        result.err()
+        validate_bundle(&bundle).is_ok(),
+        "structural validation should not perform Merkle proof crypto"
+    );
+
+    // ...but the verification path must reject the invalid Merkle proof.
+    let artifact_digest =
+        extract_artifact_digest(&bundle).expect("Bundle should have artifact digest");
+    let policy = VerificationPolicy::default().skip_timestamp();
+
+    let err = verify(artifact_digest, &bundle, &policy, &production_root())
+        .expect_err("verification must fail with a tampered inclusion proof");
+    assert!(
+        err.to_string().contains("inclusion proof"),
+        "unexpected error: {}",
+        err
+    );
+}
+
+#[test]
+fn test_tampered_canonicalized_body_fails_verification() {
+    let mut bundle = Bundle::from_json(V03_BUNDLE_DSSE).unwrap();
+
+    // Tamper with the entry body the Merkle leaf hash is computed from.
+    let entry = &mut bundle.verification_material.tlog_entries[0];
+    let mut body = entry.canonicalized_body.as_bytes().to_vec();
+    body[0] ^= 0xff;
+    entry.canonicalized_body = sigstore_verify::types::CanonicalizedBody::new(body);
+
+    let artifact_digest =
+        extract_artifact_digest(&bundle).expect("Bundle should have artifact digest");
+    let policy = VerificationPolicy::default().skip_timestamp();
+
+    let result = verify(artifact_digest, &bundle, &policy, &production_root());
+    assert!(
+        result.is_err(),
+        "verification must fail when the canonicalized body does not match the inclusion proof"
     );
 }
 


### PR DESCRIPTION
Resolves the ambiguity described in #110: `validate_bundle()` mixed structural validation with cryptographic Merkle-proof verification, while not verifying checkpoint signatures — making its contract hard to state or audit.

**New contract:**

- `validate_bundle{,_with_options}` is now **purely structural**: media-type/version conformance, version-specific shape rules, required-field presence, and inclusion-proof *well-formedness* (checkpoint parses; `log_index`/`tree_size` valid and `log_index < tree_size`; the proof's `root_hash` matches its own checkpoint's root hash — internal consistency, no keys involved). Docstrings on every public item now explicitly list what is and is **not** checked (no signature, Merkle, checkpoint, SET, timestamp, or certificate verification).
- The cryptographic checks moved to the verify path in sigstore-verify: new `verify_entry_inclusion()` per tlog entry verifies the **Merkle inclusion proof** (leaf = canonicalized body, hashed up to the proof root), the **checkpoint signature** (binding that root hash to a Rekor key from the trusted root), and the **SET**. Both `Verifier::verify` and `verify_with_key` route through it.

**No verification was weakened — coverage is equal or stronger:** previously the Merkle proof was checked against an *unauthenticated* root hash inside `validate_bundle`; now it's always checked in the verify flow against the root hash bound by the signed checkpoint. New contract-pinning tests prove it: a tampered Merkle `root_hash` or canonicalized body now *passes* structural validation but *fails* `verify()`.

Also: `sigstore-merkle` demoted to a dev-dependency of sigstore-bundle, unused `Error::Merkle` variant dropped.

One judgment call worth review: the proof-root-hash vs checkpoint-root-hash consistency check stays in structural validation (it needs no keys) *and* in `verify_checkpoint` (defense in depth). If you'd prefer structural validation to be presence/shape only, it can move out.

`cargo clippy --workspace --all-targets -- -D warnings` clean; full workspace test suite passes (rebased on top of #119).

Fixes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)