### PR TITLE
use tempfile for atomic writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2047,6 +2047,7 @@ dependencies = [
  "sha2",
  "sigstore-crypto",
  "sigstore-types",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,9 @@ futures = "0.3"
 # Directory utilities
 directories = "6.0"
 
+# Atomic file writes / temp files
+tempfile = "3.27.0"
+
 # Browser opening
 open = "5.3"
 

--- a/crates/sigstore-trust-root/Cargo.toml
+++ b/crates/sigstore-trust-root/Cargo.toml
@@ -54,6 +54,6 @@ name = "update-embedded-roots"
 required-features = ["tuf"]
 
 [dev-dependencies]
-tempfile = "3.27.0"
+tempfile = { workspace = true }
 # For testing
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }

--- a/crates/sigstore-tuf/Cargo.toml
+++ b/crates/sigstore-tuf/Cargo.toml
@@ -36,6 +36,9 @@ globset = { workspace = true }
 # Encoding
 hex = { workspace = true }
 
+# Atomic on-disk cache writes (temp file + persist/rename)
+tempfile = { workspace = true }
+
 # Time / expiration handling
 jiff = { workspace = true }
 

--- a/crates/sigstore-tuf/src/cache.rs
+++ b/crates/sigstore-tuf/src/cache.rs
@@ -11,6 +11,7 @@
 //! bypass verification — at worst it fails the refresh.
 
 use std::collections::HashMap;
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 
@@ -32,6 +33,23 @@ pub trait MetadataStore: Send + Sync {
 /// File names may contain `/`; intermediate directories are created. Names
 /// containing `..` or absolute components are rejected to prevent escaping the
 /// store root.
+///
+/// # Durability and concurrency
+///
+/// Writes are **atomic**: bytes are written to a uniquely-named temp file in
+/// the destination directory and then `rename`d over the final name. A reader
+/// therefore never observes a half-written file, and a crash mid-write leaves
+/// either the old file or the new one — never a truncated or interleaved blob.
+///
+/// As a consequence the store is **safe to share across concurrent processes**:
+/// two writers racing on the same name resolve to a clean last-writer-wins,
+/// not a corrupted file. The store deliberately does *not* provide *cross-file*
+/// atomicity (e.g. `timestamp.json` and `snapshot.json` updated as a unit) and
+/// takes no lock spanning a refresh. It does not need to: the
+/// [`Updater`](crate::client::Updater) re-verifies every cached file from the
+/// pinned root and enforces version floors on read, so a concurrently-written,
+/// internally-inconsistent set of cache files can at worst trigger a re-fetch —
+/// it can never bypass verification.
 #[derive(Debug, Clone)]
 pub struct FileStore {
     dir: PathBuf,
@@ -68,9 +86,45 @@ impl MetadataStore for FileStore {
             std::fs::create_dir_all(parent)
                 .map_err(|e| Error::Transport(format!("cache mkdir failed: {e}")))?;
         }
-        std::fs::write(&path, bytes)
-            .map_err(|e| Error::Transport(format!("cache write failed: {e}")))
+        write_atomic(&path, bytes)
     }
+}
+
+/// Write `bytes` to `path` atomically via a [`tempfile::NamedTempFile`] in the
+/// same directory followed by `persist` (an atomic rename). The temp lives in
+/// the destination directory (not `$TMPDIR`) so the rename stays within one
+/// filesystem and is therefore atomic; it carries a random name, so concurrent
+/// writers never collide, and `NamedTempFile` removes it on any error path so a
+/// crashed or losing writer leaks nothing.
+///
+/// On Windows, `persist` over a file another process currently has open can
+/// transiently fail, so the rename is retried a few times with brief backoff.
+fn write_atomic(path: &Path, bytes: &[u8]) -> Result<()> {
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let mut tmp = tempfile::NamedTempFile::new_in(dir)
+        .map_err(|e| Error::Transport(format!("cache temp create failed: {e}")))?;
+    tmp.write_all(bytes)
+        .map_err(|e| Error::Transport(format!("cache write failed: {e}")))?;
+
+    let mut to_persist = tmp;
+    for attempt in 0..5 {
+        match to_persist.persist(path) {
+            Ok(_) => return Ok(()),
+            // `persist` returns the temp file back inside the error so a retry
+            // can reuse it without rewriting the bytes.
+            Err(e) => {
+                to_persist = e.file;
+                if attempt == 4 {
+                    return Err(Error::Transport(format!(
+                        "cache rename failed: {}",
+                        e.error
+                    )));
+                }
+                std::thread::sleep(std::time::Duration::from_millis(10 * (attempt + 1)));
+            }
+        }
+    }
+    unreachable!("loop returns on the final attempt")
 }
 
 /// An in-memory [`MetadataStore`], useful for tests and ephemeral runs.
@@ -143,5 +197,68 @@ impl<S: MetadataStore> Repository for StoreRepository<S> {
     fn fetch_target<'a>(&'a self, path: &'a str, max_length: u64) -> FetchFuture<'a> {
         let res = self.read(&format!("targets/{path}"), max_length);
         Box::pin(async move { res })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Count leftover temp files (tempfile names them `.tmpXXXXXX`) in `dir`.
+    fn temp_residue(dir: &Path) -> usize {
+        std::fs::read_dir(dir)
+            .into_iter()
+            .flatten()
+            .flatten()
+            .filter(|e| e.file_name().to_string_lossy().starts_with(".tmp"))
+            .count()
+    }
+
+    #[test]
+    fn store_round_trips_and_overwrites() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = FileStore::new(dir.path());
+
+        store.store("timestamp.json", b"v1").unwrap();
+        assert_eq!(store.load("timestamp.json").as_deref(), Some(&b"v1"[..]));
+
+        // Last-writer-wins, in place.
+        store.store("timestamp.json", b"v2-longer").unwrap();
+        assert_eq!(
+            store.load("timestamp.json").as_deref(),
+            Some(&b"v2-longer"[..])
+        );
+
+        assert_eq!(store.load("absent.json"), None);
+    }
+
+    #[test]
+    fn writes_leave_no_temp_residue() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = FileStore::new(dir.path());
+
+        // Including a nested name to exercise the create_dir_all path.
+        store.store("root_history/2.root.json", b"root").unwrap();
+        store.store("snapshot.json", b"snap").unwrap();
+        store.store("snapshot.json", b"snap-again").unwrap();
+
+        assert_eq!(
+            temp_residue(dir.path()),
+            0,
+            "no temp files should remain in the store root"
+        );
+        assert_eq!(
+            temp_residue(&dir.path().join("root_history")),
+            0,
+            "no temp files should remain in nested dirs"
+        );
+    }
+
+    #[test]
+    fn rejects_paths_escaping_the_root() {
+        let dir = tempfile::tempdir().unwrap();
+        let store = FileStore::new(dir.path());
+        assert!(store.store("../escape.json", b"x").is_err());
+        assert!(store.load("../escape.json").is_none());
     }
 }

--- a/crates/sigstore-tuf/src/client.rs
+++ b/crates/sigstore-tuf/src/client.rs
@@ -420,6 +420,13 @@ impl Updater {
     /// than a path, so a caller that has already resolved the target (and
     /// perhaps checked the cache) does not pay for a second delegation walk.
     /// Mirrors python-tuf's `download_target(targetinfo)`.
+    ///
+    /// The target is **buffered fully in memory** (bounded by the pinned length,
+    /// itself capped by [`UpdaterConfig::target_max_length`]) before its hash is
+    /// verified — there is no streaming-to-disk path. This is intentional for
+    /// Sigstore's small targets (`trusted_root.json` and friends); a caller that
+    /// needs to fetch very large targets without buffering should add a
+    /// streaming variant rather than relying on this method.
     pub async fn download_target(
         &mut self,
         target: &TargetFile,


### PR DESCRIPTION
#### Summary
Improves on our previous TUF PR by using more atomic writes for the JSON files (first write to tempfile, then rename).


#### Release Note
<!--
Add a release note for each of the following conditions:

* Config changes (additions, deletions, updates)
* API additions—new endpoint, new response fields, or newly accepted request parameters
* Database changes (any)
* Websocket additions or changes
* Anything noteworthy to an administrator running private sigstore instances (err on the side of over-communicating)
* New features and improvements, including behavioural changes, UI changes and CLI changes
* Bug fixes and fixes of previous known issues
* Deprecation warnings, breaking changes, or compatibility notes

If no release notes are required write NONE. Use past-tense.

-->

#### Documentation
<!--

Does this change require an update to documentation? How will users implement your new feature?

Please reference a PR within https://docs.sigstore.dev

-->
